### PR TITLE
Refactor task api

### DIFF
--- a/components/TableCell.py
+++ b/components/TableCell.py
@@ -17,7 +17,6 @@
 
 from utils.task import Task
 from PySide6 import QtCore, QtWidgets
-from utils import taskWarriorInstance
 from typing import Callable, Optional
 
 class TableCell(QtWidgets.QLabel):

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -15,7 +15,6 @@
  *  Known Faults: None encountered
 """
 
-from utils.task import Task
 from PySide6 import QtCore, QtWidgets
 from utils import api
 from .checkbox import Checkbox
@@ -181,19 +180,7 @@ class TaskRow:
         grid.addWidget(self.delete_button, rowNum, len(self.cols) + 2)  # add the delete button to the grid
 
     def update_task(self):
-
-        # Uncomment the print lines for debugging, if necessary.
-        # if self.task:
-        #     print(f"taskID: {self.task.get_id()} => ", end="")
-        # else:
-        #     print("taskID: None => ", end="")
-
         self.task = api.task_at(self.idx)
-        
-        # if self.task:
-        #     print(self.task.get_id())
-        # else:
-        #     print("None")
 
         self.check.update_task()
         for i in range(len(self.cols)):

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -21,7 +21,7 @@ from utils import api
 from .checkbox import Checkbox
 from .textbox import Textbox
 from .buttonbox import Buttonbox
-from typing import Final, Optional
+from typing import Final, Optional, Callable
 
 
 # The names of the columns.
@@ -158,15 +158,15 @@ class EditTaskDialog(QtWidgets.QDialog):
 
 
 class TaskRow:
-    def __init__(self, row_num: int):
+    def __init__(self, row_num: int, edit_task: Callable[[int], None], delete_task: Callable[[int], None]):
         self.idx = row_num
 
         self.task = api.task_at(self.idx)
         self.check = Checkbox(row_num, self.get_task)
         self.cols = [Textbox(row_num, self.get_task, attr) for attr in COLS]
 
-        self.edit_button = Buttonbox(row_num, self.get_task, "edit", self._edit_task)
-        self.delete_button = Buttonbox(row_num, self.get_task, "delete", self._delete_task)
+        self.edit_button = Buttonbox(row_num, self.get_task, "edit", lambda: edit_task(row_num))
+        self.delete_button = Buttonbox(row_num, self.get_task, "delete", lambda: delete_task(row_num))
 
     def get_task(self): return self.task
 
@@ -201,28 +201,29 @@ class TaskRow:
             self.cols[i].update_task()
         self.edit_button.update_task()
         self.delete_button.update_task()
+        print(self.idx , self.task)
     
-    def _edit_task(self):
-        assert self.task
+    # def _edit_task(self):
+    #     assert self.task
 
-        edit_task_dialog = EditTaskDialog(str(self.task.get("description") or ""), 
-          str(self.task.get("due") or ""), 
-          str(self.task.get("priority") or ""))
+    #     edit_task_dialog = EditTaskDialog(str(self.task.get("description") or ""), 
+    #       str(self.task.get("due") or ""), 
+    #       str(self.task.get("priority") or ""))
         
-        if edit_task_dialog.exec():
-            self.task.set("description", edit_task_dialog.description or None)
-            self.task.set("due", edit_task_dialog.due or None)
-            self.task.set("priority", edit_task_dialog.priority or None)
-            api.update_task(self.task)
-            self.update_task()
+    #     if edit_task_dialog.exec():
+    #         self.task.set("description", edit_task_dialog.description or None)
+    #         self.task.set("due", edit_task_dialog.due or None)
+    #         self.task.set("priority", edit_task_dialog.priority or None)
+    #         api.update_task(self.task)
+    #         self.update_task()
             
-    def _delete_task(self):
-        assert self.task  # throw error if called without a task
-        uuid = self.task.get_uuid()
-        taskWarriorInstance.task_delete(uuid=uuid)  # delete task with the corresponding id
-        self._remove_task_row()  # remove the task row from the UI
+    # def _delete_task(self):
+    #     assert self.task  # throw error if called without a task
+    #     uuid = self.task.get_uuid()
+    #     taskWarriorInstance.task_delete(uuid=uuid)  # delete task with the corresponding id
+    #     self._remove_task_row()  # remove the task row from the UI
 
-    def _remove_task_row(self):
+    def annihilate(self):
         # Get the parent grid layout
         grid = self.check.parentWidget().layout()
         if not grid:

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -156,7 +156,6 @@ class EditTaskDialog(QtWidgets.QDialog):
     def priority(self):
         return self._priority_text.text()
 
-
 class TaskRow:
     def __init__(self, row_num: int, edit_task: Callable[[int], None], delete_task: Callable[[int], None]):
         self.idx = row_num
@@ -201,27 +200,6 @@ class TaskRow:
             self.cols[i].update_task()
         self.edit_button.update_task()
         self.delete_button.update_task()
-        print(self.idx , self.task)
-    
-    # def _edit_task(self):
-    #     assert self.task
-
-    #     edit_task_dialog = EditTaskDialog(str(self.task.get("description") or ""), 
-    #       str(self.task.get("due") or ""), 
-    #       str(self.task.get("priority") or ""))
-        
-    #     if edit_task_dialog.exec():
-    #         self.task.set("description", edit_task_dialog.description or None)
-    #         self.task.set("due", edit_task_dialog.due or None)
-    #         self.task.set("priority", edit_task_dialog.priority or None)
-    #         api.update_task(self.task)
-    #         self.update_task()
-            
-    # def _delete_task(self):
-    #     assert self.task  # throw error if called without a task
-    #     uuid = self.task.get_uuid()
-    #     taskWarriorInstance.task_delete(uuid=uuid)  # delete task with the corresponding id
-    #     self._remove_task_row()  # remove the task row from the UI
 
     def annihilate(self):
         # Get the parent grid layout

--- a/components/buttonbox.py
+++ b/components/buttonbox.py
@@ -1,6 +1,5 @@
 from utils.task import Task
 from PySide6 import QtCore, QtWidgets, QtGui
-from utils import taskWarriorInstance
 from typing import Final
 from .TableCell import TableCell
 from typing import Callable, Optional

--- a/components/checkbox.py
+++ b/components/checkbox.py
@@ -35,7 +35,11 @@ class Checkbox(TableCell):
         super().update_task()  # Call the parent update task method.
         if self.active:  # If the cell is active.
             assert self.task  # Assert that the task is not None.
+            self.my_checkbox.setEnabled(True)
             self.my_checkbox.setChecked(self.task.get_status() == 'completed')  # Set the checked state of the checkbox to the status of the task.
+        else:
+            self.my_checkbox.setChecked(False)
+            self.my_checkbox.setEnabled(False)
         self.update()  # Update the cell.
 
     @QtCore.Slot()

--- a/components/checkbox.py
+++ b/components/checkbox.py
@@ -17,7 +17,7 @@
 
 from utils.task import Task
 from PySide6 import QtCore, QtWidgets
-from utils import taskWarriorInstance
+from utils import api
 from .TableCell import TableCell
 from typing import Callable, Optional
 
@@ -44,8 +44,10 @@ class Checkbox(TableCell):
         assert self.task  # Assert that the task is not None.
 
         if self.my_checkbox.isChecked():  # If the checkbox is checked.
-            taskWarriorInstance.task_update({"uuid": self.task.get_uuid(), "status": 'completed'})  # Update the task status to completed.
+            self.task.set('status', 'completed')
 
         else:  # If the checkbox is not checked.
-            taskWarriorInstance.task_update({"uuid": self.task.get_uuid(), "status": 'pending'})  # Update the task status to pending.
+            self.task.set('status', 'pending')
+            
+        api.update_task(self.task)  # Update the task status.
 

--- a/components/textbox.py
+++ b/components/textbox.py
@@ -39,4 +39,7 @@ class Textbox(TableCell):
             assert self.attribute  # Assert that the attribute is not None.
             self.my_text = str(self.task.get(self.attribute) or "")  # Set the text of the label to the attribute of the task.
             self.my_label.setText(self.my_text)  # Set the text of the label to the text.
+        else:
+            self.my_text = ""
+            self.my_label.setText("")
         self.update()  # Update the cell.

--- a/components/textbox.py
+++ b/components/textbox.py
@@ -17,7 +17,6 @@
 
 from utils.task import Task
 from PySide6 import QtCore, QtWidgets, QtGui
-from utils import taskWarriorInstance
 from typing import Callable, Optional
 from .TableCell import TableCell
 

--- a/taskchampion.py
+++ b/taskchampion.py
@@ -17,13 +17,11 @@
 
 import sys
 from PySide6 import QtCore, QtWidgets
-from taskw_ng import TaskWarrior
 from typing import TypeAlias, Literal, Callable
-from utils.task import Task, status_t, priority_t
 from components import AddTaskDialog, TaskRow, COLS, ALIGN, menubar, EditTaskDialog
 from utils import api
 
-refreshStyles: Callable[[], None]
+refresh_styles: Callable[[], None]
 
 class GridWidget(QtWidgets.QWidget):
     '''The widget that corresponds to a module'''
@@ -48,7 +46,6 @@ class GridWidget(QtWidgets.QWidget):
         self.rowArr: list[TaskRow] = []  # Initialize the row array to an empty list.
 
         self.addHeader()  # Add the header to the grid.
-        # self.fillGrid()  # Fill the grid with the default number of rows.
 
         self.menu_bar = None    # declare the window's menu bar
         self.set_menu_bar()     # set the window's menu bar
@@ -75,8 +72,7 @@ class GridWidget(QtWidgets.QWidget):
         for row in range(len(self.rowArr)):
             self.rowArr[row].update_task()
         
-        refreshStyles()
-
+        refresh_styles()
 
     def addHeader(self):
         # Make header row take up as little vertical space as it needs.
@@ -100,7 +96,7 @@ class GridWidget(QtWidgets.QWidget):
         self.menu_bar = menubar.MenuBar()  # Create a new menu bar.
 
     def fillGrid(self):
-        # TODO: Currently this also adds tasks to the grid, which may not be ideal? Evaluate.
+        # Also adds tasks to the grid, which doesn't work for the "example" tab. So for now, it's empty.
 
         for i in range(self.DEFAULT_ROWS):  # Loop through the default number of rows.
             self.rowArr.append(TaskRow(i, self._edit_task, self._delete_task))  # Append a new task row to the row array.
@@ -125,11 +121,11 @@ class GridWidget(QtWidgets.QWidget):
             for i in range(api.num_tasks()):
                 self.rowArr[i].update_task()
 
-        refreshStyles()
+        refresh_styles()
             
     def _delete_task(self, idx: int):
         """passed to taskrows."""
-        api.del_at(idx)
+        api.delete_at(idx)
         
         num_tasks = api.num_tasks()
 
@@ -139,7 +135,7 @@ class GridWidget(QtWidgets.QWidget):
         for i in range(len(self.rowArr)):
             self.rowArr[i].update_task()
 
-        refreshStyles()
+        refresh_styles()
 
 class TaskChampionWidget(QtWidgets.QWidget):
     '''The main widget for the Task Champion application.'''
@@ -218,7 +214,6 @@ class TaskChampionGUI:
 
     def loadTasks(self):
         self.mainWidget.grids[0].fillGrid()
-        self.loadStyles()
 
     def loadStyles(self):
         self.qtapp.setStyleSheet(self._styleStr)  # Set the style sheet of the Qt Application to be the style string.
@@ -230,12 +225,7 @@ class TaskChampionGUI:
 # Program entry point
 if __name__ == "__main__":
     app = TaskChampionGUI()  # Create a new TaskChampionGUI object.
-    
-
-    # # Add both pending and completed tasks.
-    # for task in [*tasks['pending'], *tasks['completed']]:  # Loop through the tasks.
-    #     app.mainWidget.grids[0].addTask(Task(task))  # Add the task to the first grid.
     app.loadTasks()
-    refreshStyles = app.loadStyles
-  
+    # TODO: Consider doing this in a better way.
+    refresh_styles = app.loadStyles
     sys.exit(app.on_exit())  # Exit the application.

--- a/taskchampion.py
+++ b/taskchampion.py
@@ -46,7 +46,7 @@ class GridWidget(QtWidgets.QWidget):
         self.rowArr: list[TaskRow] = []  # Initialize the row array to an empty list.
 
         self.addHeader()  # Add the header to the grid.
-        self.fillGrid()  # Fill the grid with the default number of rows.
+        # self.fillGrid()  # Fill the grid with the default number of rows.
 
         self.menu_bar = None    # declare the window's menu bar
         self.set_menu_bar()     # set the window's menu bar
@@ -65,12 +65,12 @@ class GridWidget(QtWidgets.QWidget):
         if self.grid.rowCount() == num_tasks:  # If the row count of the grid is equal to the number of rows.
             self.setMinimumHeight(num_tasks * self.ROW_HEIGHT)  # Set the minimum height of the widget to be the number of rows times the row height.
 
-            self.rowArr.append(TaskRow(num_tasks))  # Append a new task row to the row array.
+            self.rowArr.append(TaskRow(num_tasks, self._edit_task, self._delete_task))  # Append a new task row to the row array.
             self.rowArr[num_tasks-1].insert(self.grid, num_tasks)
 
             # Row inserts itself into the grid, insertion logic is handled in `TaskRow` obj.
             
-        for row in range(num_tasks):
+        for row in range(len(self.rowArr)):
             self.rowArr[row].update_task()
         
 
@@ -97,9 +97,10 @@ class GridWidget(QtWidgets.QWidget):
 
     def fillGrid(self):
         for i in range(self.DEFAULT_ROWS):  # Loop through the default number of rows.
-            self.rowArr.append(TaskRow(i))  # Append a new task row to the row array.
+            self.rowArr.append(TaskRow(i, self._edit_task, self._delete_task))  # Append a new task row to the row array.
             self.rowArr[i].insert(self.grid, i+1)  # Insert the row into the grid.
         self.setMinimumHeight(self.DEFAULT_ROWS * self.ROW_HEIGHT)  # Set the minimum height of the widget to be the default number of rows times the row height.
+
 
     def _edit_task(self, idx: int):
         """Passed to taskrows."""
@@ -116,8 +117,26 @@ class GridWidget(QtWidgets.QWidget):
             cur_task.set("priority", edit_task_dialog.priority or None)
             api.update_task(cur_task)
 
+            for i in range(api.num_tasks()):
+                self.rowArr[i].update_task()
+            
+
     def _delete_task(self, idx: int):
         """passed to taskrows."""
+        api.del_at(idx)
+        
+        num_tasks = api.num_tasks()
+
+        if num_tasks > self.DEFAULT_ROWS:
+            self.rowArr.pop(-1).annihilate()
+        
+            
+        for i in range(len(self.rowArr)):
+            self.rowArr[i].update_task()
+            
+
+        
+
         
 
 class TaskChampionWidget(QtWidgets.QWidget):

--- a/taskchampion.py
+++ b/taskchampion.py
@@ -20,8 +20,8 @@ from PySide6 import QtCore, QtWidgets
 from taskw_ng import TaskWarrior
 from typing import TypeAlias, Literal
 from utils.task import Task, status_t, priority_t
-from components import AddTaskDialog, TaskRow, COLS, ALIGN, menubar
-from utils import taskWarriorInstance
+from components import AddTaskDialog, TaskRow, COLS, ALIGN, menubar, EditTaskDialog
+from utils import api
 
 class GridWidget(QtWidgets.QWidget):
     '''The widget that corresponds to a module'''
@@ -41,10 +41,8 @@ class GridWidget(QtWidgets.QWidget):
 
         self.grid.rowMinimumHeight(self.ROW_HEIGHT)  # Set the minimum height of the rows in the grid.
 
-        # print(self.scrollArea.alignment())  
         self.setLayout(self.grid)  # Set the layout of the widget to be the grid layout.
 
-        self.rows = 0  # Initialize the number of rows to 0.
         self.rowArr: list[TaskRow] = []  # Initialize the row array to an empty list.
 
         self.addHeader()  # Add the header to the grid.
@@ -53,23 +51,28 @@ class GridWidget(QtWidgets.QWidget):
         self.menu_bar = None    # declare the window's menu bar
         self.set_menu_bar()     # set the window's menu bar
 
-    def addTask(self, newTask: Task) -> None:
+    def addTask(self) -> None:
+        """Assumes that addTask has already been called in TaskChampionGUI. 
         
-        self.rows += 1  # Increment the number of rows.
+        Since that means TaskAPI has the updated list of tasks, 
+        all we need to do is:
+
+        1) See if we need to add a new `TaskRow`
+        2) broadcast to all `TaskRow`s to update their current task.
+        """
+        num_tasks = api.num_tasks()  # Increment the number of rows.
             
-        uuid = str(newTask.get_uuid())  # Get the UUID of the new task.
+        if self.grid.rowCount() == num_tasks:  # If the row count of the grid is equal to the number of rows.
+            self.setMinimumHeight(num_tasks * self.ROW_HEIGHT)  # Set the minimum height of the widget to be the number of rows times the row height.
 
-        if self.grid.rowCount() == self.rows:  # If the row count of the grid is equal to the number of rows.
-            self.setMinimumHeight(self.rows * self.ROW_HEIGHT)  # Set the minimum height of the widget to be the number of rows times the row height.
+            self.rowArr.append(TaskRow(num_tasks))  # Append a new task row to the row array.
+            self.rowArr[num_tasks-1].insert(self.grid, num_tasks)
 
-            self.rowArr.append(TaskRow(self.rows, uuid))  # Append a new task row to the row array.
             # Row inserts itself into the grid, insertion logic is handled in `TaskRow` obj.
-            # Note that this may be tricky when changing order of tasks w.r.t column sorting, 
-            # as that logic will happen in this class.
-            # but idk what method we will use for sorting, for all I know qt makes it very easy.    
-           
-        self.rowArr[self.rows-1].update_task(uuid)  # Update the task in the row array.
-        self.rowArr[self.rows-1].insert(self.grid, self.rows)  # Insert the row into the grid.
+            
+        for row in range(num_tasks):
+            self.rowArr[row].update_task()
+        
 
     def addHeader(self):
         # Make header row take up as little vertical space as it needs.
@@ -94,9 +97,28 @@ class GridWidget(QtWidgets.QWidget):
 
     def fillGrid(self):
         for i in range(self.DEFAULT_ROWS):  # Loop through the default number of rows.
-            self.rowArr.append(TaskRow(i, ""))  # Append a new task row to the row array.
+            self.rowArr.append(TaskRow(i))  # Append a new task row to the row array.
             self.rowArr[i].insert(self.grid, i+1)  # Insert the row into the grid.
         self.setMinimumHeight(self.DEFAULT_ROWS * self.ROW_HEIGHT)  # Set the minimum height of the widget to be the default number of rows times the row height.
+
+    def _edit_task(self, idx: int):
+        """Passed to taskrows."""
+        cur_task = api.task_at(idx)
+        assert cur_task
+
+        edit_task_dialog = EditTaskDialog(str(cur_task.get("description") or ""), 
+            str(cur_task.get("due") or ""), 
+            str(cur_task.get("priority") or ""))
+        
+        if edit_task_dialog.exec():
+            cur_task.set("description", edit_task_dialog.description or None)
+            cur_task.set("due", edit_task_dialog.due or None)
+            cur_task.set("priority", edit_task_dialog.priority or None)
+            api.update_task(cur_task)
+
+    def _delete_task(self, idx: int):
+        """passed to taskrows."""
+        
 
 class TaskChampionWidget(QtWidgets.QWidget):
     '''The main widget for the Task Champion application.'''
@@ -137,18 +159,26 @@ class TaskChampionWidget(QtWidgets.QWidget):
         if newTaskDetails == None:  # If the new task details are None.
             return  # Return.
 
-        newTask : Task = Task(taskWarriorInstance.task_add(newTaskDetails.description, newTaskDetails.tag))  # Create a new task with the details from the add task dialog.
+        api.add_new_task(
+            description = newTaskDetails.description, 
+            tag         = newTaskDetails.tag,
+            priority    = newTaskDetails.priority,
+            project     = newTaskDetails.project,
+            recur       = newTaskDetails.recurrence,
+            due         = newTaskDetails.due,
+        )  # Create a new task with the details from the add task dialog.
         
-        newTask.set_priority(newTaskDetails.priority)  # Set the priority of the new task.
-        newTask.set_project(newTaskDetails.project)   # Set the project of the new task.
+        # newTask.set_priority(newTaskDetails.priority)  # Set the priority of the new task.
+        # newTask.set_project(newTaskDetails.project)   # Set the project of the new task.
 
-        if newTaskDetails.recurrence != None:  # If the recurrence of the new task is not None.
-            newTask.set_recur(newTaskDetails.recurrence)  # Set the recurrence of the new task.
-        if newTaskDetails.due != None:  # If the due date of the new task is not None.
-            newTask.set_due(newTaskDetails.due)  # Set the due date of the new task.
+        # if newTaskDetails.recurrence != None:  # If the recurrence of the new task is not None.
+        #     newTask.set_recur(newTaskDetails.recurrence)  # Set the recurrence of the new task.
+        # if newTaskDetails.due != None:  # If the due date of the new task is not None.
+        #     newTask.set_due(newTaskDetails.due)  # Set the due date of the new task.
 
-        taskWarriorInstance.task_update(newTask)  # Update the new task in TaskWarrior.
-        self.grids[self.currentGrid].addTask(newTask)  # Add the new task to the current grid.
+        # TaskAPI().update(newTask)  # Update the new task in TaskWarrior.
+
+        self.grids[self.currentGrid].addTask()  # Add the new task to the current grid.
 
     def set_menu_bar(self):
         """Sets the menu bar for the application."""  
@@ -167,11 +197,18 @@ class TaskChampionGUI:
         self.mainWidget.setWindowTitle("Task Champion")  # Set the window title.
         self.mainWidget.resize(800, 400) # set basic window size.
         self.mainWidget.show() # show the window
+
+        self.mainWidget.move(0, 0)
+
         self._styleStr = ""  # Initialize the style string.
         with open ('styles/style.qss', 'r')as f:  # Open the style file.
             self._styleStr = f.read()  # Read the style file.
 
         self.loadStyles()  # Load the styles.
+
+    def loadTasks(self):
+        self.mainWidget.grids[0].fillGrid()
+        self.loadStyles()
 
     def loadStyles(self):
         self.qtapp.setStyleSheet(self._styleStr)  # Set the style sheet of the Qt Application to be the style string.
@@ -183,12 +220,12 @@ class TaskChampionGUI:
 # Program entry point
 if __name__ == "__main__":
     app = TaskChampionGUI()  # Create a new TaskChampionGUI object.
-    tasks = taskWarriorInstance.load_tasks()  # Load the tasks from TaskWarrior.
-
-    # Add both pending and completed tasks.
-    for task in [*tasks['pending'], *tasks['completed']]:  # Loop through the tasks.
-        app.mainWidget.grids[0].addTask(Task(task))  # Add the task to the first grid.
     
-    app.loadStyles()  # Load the styles.
+
+    # # Add both pending and completed tasks.
+    # for task in [*tasks['pending'], *tasks['completed']]:  # Loop through the tasks.
+    #     app.mainWidget.grids[0].addTask(Task(task))  # Add the task to the first grid.
+    app.loadTasks()
+    # app.loadStyles()  # Load the styles.
   
     sys.exit(app.on_exit())  # Exit the application.

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -16,5 +16,137 @@
 """
 
 from taskw_ng.warrior import TaskWarrior
+from .task import Task
+from enum import Enum
+from typing import Callable, Optional
 
-taskWarriorInstance = TaskWarrior()  # Create a TaskWarrior instance.
+
+def singleton(cls):
+    instances = {}
+    def getinstance(*args, **kwargs):
+        if cls not in instances:
+            instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+    return getinstance
+
+class SortMetric(Enum):
+    ID_ASCENDING          = 0
+    ID_DECENDING          = 1
+    PRIORITY_ASCENDING    = 2
+    PRIORITY_DECENDING    = 3
+    DESCRIPTION_ASCENDING = 4
+    DESCRIPTION_DECENDING = 5
+    # TODO: Add wayy more
+
+
+@singleton
+class TaskAPI:
+    
+   
+
+    @staticmethod
+    def _get_sort_params(metric: SortMetric) -> tuple[Callable[[Task], str | int], bool]:
+        """Meant to be called in `self._init_task_list()` by doing the following:
+        
+        ```
+        k, r = self._get_sort_params(self.sort_metric)
+        self.task_list.sort(key=k, reverse=r)
+        ```
+        That's it.
+
+        """
+        
+        def alpha_sorting(attr_name: str):
+            """Used whenever the attribute we are sorting by follows alphanumeric sorting rules.
+            
+            Ignores capitalization.
+
+            Examples: description, id, project.
+            Counterexamples: priority."""
+            
+            def subFn(t: Task):
+                return str(t[attr_name]).lower()
+            
+            return subFn
+
+        def priority_sorting(t: Task): 
+            match t.get_priority():
+                case 'H':
+                    return 1
+                case 'M':
+                    return 2
+                case 'L':
+                    return 3
+                case _:
+                    return 0
+
+        match metric:
+            case SortMetric.ID_ASCENDING:
+                return alpha_sorting('id'), False
+            case SortMetric.ID_DECENDING:
+                return alpha_sorting('id'), True
+            case SortMetric.PRIORITY_ASCENDING:
+                return priority_sorting, False
+            case SortMetric.PRIORITY_DECENDING:
+                return priority_sorting, True
+            case SortMetric.DESCRIPTION_ASCENDING:
+                return alpha_sorting('description'), False
+            case SortMetric.DESCRIPTION_DECENDING:
+                return alpha_sorting('description'), True
+
+    def __init__(self):
+        self.warrior = TaskWarrior()
+        self.sort_metric: SortMetric = SortMetric.ID_ASCENDING
+
+        self.task_list: list[Task] = []
+        '''The list that is sorted according to some criteria'''
+
+        self._init_task_list()
+
+    def _init_task_list(self) -> None:
+        """Refreshes the task list. Private.
+        Done after any operation that would require re-sorting the list of tasks."""
+        self.task_list.clear()
+
+        tasks = self.warrior.load_tasks()
+        self.task_list = [Task(x) for x in tasks['pending'] + tasks['completed']]
+        
+        k, r = self._get_sort_params(self.sort_metric)
+        self.task_list.sort(key=k, reverse=r)
+
+    def num_tasks(self) -> int:
+        return len(self.task_list)
+        
+    def task_at(self, idx: int) -> Optional[Task]:
+        if len(self.task_list) <= idx:
+            return None
+        
+        return self.task_list[idx]
+
+    
+    def add_new_task(self, description: str, tags=None, **kw):
+        self.warrior.task_add(description, tags, **kw)
+        self._init_task_list()
+
+    def add_task(self, t: Task) -> None:
+        self.warrior.task_add(t)
+        self._init_task_list()
+
+    def del_at(self, idx: int) -> None:
+
+        if len(self.task_list) <= idx:
+            return
+
+        t = self.task_list.pop(idx)
+        self.warrior.task_delete(uuid=str(t['uuid']))
+
+    def update_task(self, newTask: Task) -> None:
+        self.warrior.task_update(newTask)
+
+    def set_sort_metric(self, metric: SortMetric):
+        self.sort_metric = metric
+        self._init_task_list()
+
+api = TaskAPI()
+
+# taskWarriorInstance = TaskWarrior()  # Create a TaskWarrior instance.

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -31,11 +31,11 @@ def singleton(cls):
 
 class SortMetric(Enum):
     ID_ASCENDING          = 0
-    ID_DECENDING          = 1
+    ID_DESCENDING          = 1
     PRIORITY_ASCENDING    = 2
-    PRIORITY_DECENDING    = 3
+    PRIORITY_DESCENDING    = 3
     DESCRIPTION_ASCENDING = 4
-    DESCRIPTION_DECENDING = 5
+    DESCRIPTION_DESCENDING = 5
     # TODO: Add wayy more
 
 
@@ -81,15 +81,15 @@ class TaskAPI:
         match metric:
             case SortMetric.ID_ASCENDING:
                 return alpha_sorting('id'), False
-            case SortMetric.ID_DECENDING:
+            case SortMetric.ID_DESCENDING:
                 return alpha_sorting('id'), True
             case SortMetric.PRIORITY_ASCENDING:
                 return priority_sorting, False
-            case SortMetric.PRIORITY_DECENDING:
+            case SortMetric.PRIORITY_DESCENDING:
                 return priority_sorting, True
             case SortMetric.DESCRIPTION_ASCENDING:
                 return alpha_sorting('description'), False
-            case SortMetric.DESCRIPTION_DECENDING:
+            case SortMetric.DESCRIPTION_DESCENDING:
                 return alpha_sorting('description'), True
 
     def __init__(self):
@@ -141,6 +141,7 @@ class TaskAPI:
 
     def update_task(self, newTask: Task) -> None:
         self.warrior.task_update(newTask)
+        self._init_task_list()
 
     def set_sort_metric(self, metric: SortMetric):
         self.sort_metric = metric

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -94,8 +94,8 @@ class TaskAPI:
         self.warrior = TaskWarrior()
         self.sort_metric: SortMetric = SortMetric.DESCRIPTION_ASCENDING
 
+        # The list that is sorted according to some criteria.
         self.task_list: list[Task] = []
-        "The list that is sorted according to some criteria"
 
         self._init_task_list()
 
@@ -130,7 +130,7 @@ class TaskAPI:
         self.warrior.task_add(t)
         self._init_task_list()
 
-    def del_at(self, idx: int) -> None:
+    def delete_at(self, idx: int) -> None:
         if len(self.task_list) <= idx:
             return
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -41,8 +41,6 @@ class SortMetric(Enum):
 
 @singleton
 class TaskAPI:
-    
-   
 
     @staticmethod
     def _get_sort_params(metric: SortMetric) -> tuple[Callable[[Task], str | int], bool]:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -20,7 +20,6 @@ from .task import Task
 from enum import Enum
 from typing import Callable, Optional
 
-
 def singleton(cls):
     instances = {}
     def getinstance(*args, **kwargs):
@@ -30,14 +29,13 @@ def singleton(cls):
     return getinstance
 
 class SortMetric(Enum):
-    ID_ASCENDING          = 0
+    ID_ASCENDING           = 0
     ID_DESCENDING          = 1
-    PRIORITY_ASCENDING    = 2
+    PRIORITY_ASCENDING     = 2
     PRIORITY_DESCENDING    = 3
-    DESCRIPTION_ASCENDING = 4
+    DESCRIPTION_ASCENDING  = 4
     DESCRIPTION_DESCENDING = 5
     # TODO: Add wayy more
-
 
 @singleton
 class TaskAPI:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -94,16 +94,17 @@ class TaskAPI:
 
     def __init__(self):
         self.warrior = TaskWarrior()
-        self.sort_metric: SortMetric = SortMetric.ID_ASCENDING
+        self.sort_metric: SortMetric = SortMetric.DESCRIPTION_ASCENDING
 
         self.task_list: list[Task] = []
-        '''The list that is sorted according to some criteria'''
+        "The list that is sorted according to some criteria"
 
         self._init_task_list()
 
     def _init_task_list(self) -> None:
         """Refreshes the task list. Private.
-        Done after any operation that would require re-sorting the list of tasks."""
+
+        Called after any operation that would require re-sorting the list of tasks."""
         self.task_list.clear()
 
         tasks = self.warrior.load_tasks()
@@ -120,18 +121,18 @@ class TaskAPI:
             return None
         
         return self.task_list[idx]
-
     
     def add_new_task(self, description: str, tags=None, **kw):
         self.warrior.task_add(description, tags, **kw)
         self._init_task_list()
 
     def add_task(self, t: Task) -> None:
+        # Unused at the moment.
+
         self.warrior.task_add(t)
         self._init_task_list()
 
     def del_at(self, idx: int) -> None:
-
         if len(self.task_list) <= idx:
             return
 
@@ -146,5 +147,3 @@ class TaskAPI:
         self._init_task_list()
 
 api = TaskAPI()
-
-# taskWarriorInstance = TaskWarrior()  # Create a TaskWarrior instance.


### PR DESCRIPTION
This closes #21.

Adds the class `TaskAPI`, a wrapper around `taskw_ng.warrior.TaskWarrior()`.

Strips most task logic away from `TaskRow` class. Now, all they do is:
- Receive method calls saying that they should refresh the data displayed in its widgets
- Call delegate methods passed from GridWidget to edit / delete the task they contain
- Mark their task as pending / completed through their associated checkbox.

Additionally, this PR allows TaskRow styles to update after application has been launched.

Finally, supports different sorting methods of the list of tasks besides task id.
Currently, supports sorting by description, priority, and task id.
Sorting can be done in ascending or descending order.
Currently, these can only be set by hardcoded values in the `TaskAPI` class.