### PR TITLE
Feature xp config

### DIFF
--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -17,8 +17,6 @@
 
 from PySide6 import QtWidgets
 from typing import Optional
-from components.Dialogs.define_xp_dialog import XPConfigDialog
-
 
 class AddTaskDialog(QtWidgets.QDialog):
     class TaskDetails:
@@ -71,15 +69,6 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.form.addRow("Due Date", self.due_date)
 
         self.layout : QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
-        self.tabs = QtWidgets.QTabWidget() # create a tab widget to hold the task details and xp configuration tabs
-        self.task_details_tab = QtWidgets.QWidget() # create a new tab for the task details
-        self.task_details_tab.setLayout(self.form) # set the layout of the task details tab to the form
-        self.tabs.addTab(self.task_details_tab, "Task Details") # add the task details tab to the tabs
-
-        self.xp_config_tab = XPConfigDialog() # create the xp configuration tab
-        self.tabs.addTab(self.xp_config_tab, "XP Configuration") # add the xp configuration tab to the tabs
-
-        self.layout.addWidget(self.tabs) # add the tabs to the layout
 
         self.layout.addLayout(self.form)
         self.layout.addWidget(self.buttons)

--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -76,7 +76,7 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.task_details_tab.setLayout(self.form) # set the layout of the task details tab to the form
         self.tabs.addTab(self.task_details_tab, "Task Details") # add the task details tab to the tabs
 
-        self.xp_config_tab = XPConfigDialog(config_file="user_defined_xp.json") # create the xp configuration tab
+        self.xp_config_tab = XPConfigDialog() # create the xp configuration tab
         self.tabs.addTab(self.xp_config_tab, "XP Configuration") # add the xp configuration tab to the tabs
 
         self.layout.addWidget(self.tabs) # add the tabs to the layout

--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 2/23/2025
+ *  Last Modified: 2/28/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -17,6 +17,7 @@
 
 from PySide6 import QtWidgets
 from typing import Optional
+from components.Dialogs.define_xp_dialog import XPConfigDialog
 
 
 class AddTaskDialog(QtWidgets.QDialog):
@@ -30,6 +31,7 @@ class AddTaskDialog(QtWidgets.QDialog):
             self.due = due
 
     def __init__(self):
+
         super().__init__()
 
         self.form = QtWidgets.QFormLayout()
@@ -69,6 +71,16 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.form.addRow("Due Date", self.due_date)
 
         self.layout : QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
+        self.tabs = QtWidgets.QTabWidget() # create a tab widget to hold the task details and xp configuration tabs
+        self.task_details_tab = QtWidgets.QWidget() # create a new tab for the task details
+        self.task_details_tab.setLayout(self.form) # set the layout of the task details tab to the form
+        self.tabs.addTab(self.task_details_tab, "Task Details") # add the task details tab to the tabs
+
+        self.xp_config_tab = XPConfigDialog(config_file="user_defined_xp.json") # create the xp configuration tab
+        self.tabs.addTab(self.xp_config_tab, "XP Configuration") # add the xp configuration tab to the tabs
+
+        self.layout.addWidget(self.tabs) # add the tabs to the layout
+
         self.layout.addLayout(self.form)
         self.layout.addWidget(self.buttons)
 

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -111,11 +111,11 @@ class XPConfigDialog(QDialog):
         self.config['priorities'] = priorities # Update the priorities
         self.config['tags'] = tags
 
-        self.update_xp_values() # Update the XP values
+        # Tell XpControllerWidget to update stuff.
+        self.xp_values_updated.emit(self.config)
 
         with open(self.config_file, 'w') as file:
             json.dump(self.config, file)
-
 
         QMessageBox.information(self, "Success", "Configuration saved!", QMessageBox.StandardButtons.Ok)
 
@@ -137,12 +137,3 @@ class XPConfigDialog(QDialog):
         self.tag_table.setItem(row_position, 0, QTableWidgetItem(""))
         self.tag_table.setItem(row_position, 1, QTableWidgetItem(""))
 
-    def update_xp_values(self):
-        """Updates the default values of the XP earned for each priority and tag."""
-        updated_xp_values = {
-            'H': self.priority_table.item(0, 1).text(), # Get the XP value for the high priority
-            'M': self.priority_table.item(1, 1).text(), # Get the XP value for the medium priority
-            'L': self.priority_table.item(2, 1).text() # Get the XP value for the low priority
-        }
-
-        self.xp_values_updated.emit(updated_xp_values) # Emit the signal with the updated XP values

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -1,0 +1,125 @@
+"""
+ *  Module Name: define_xp_dialog.py
+ *  Purpose: Defines the XP configuration dialog.
+ *  Inputs: None
+ *  Outputs: None
+ *  Additional code sources: None
+ *  Developers: Mo Morgan
+ *  Date: 2/15/2025
+ *  Last Modified: 2/28/2025
+ *  Preconditions: None
+ *  Postconditions: None
+ *  Error/Exception conditions: FileNotFoundError: if the configuration file does not exist, json.JSONDecodeError:
+                                if the contents of the configuration file are not valid JSON.
+ *  Side effects: None
+ *  Invariants: None
+ *  Known Faults: None encountered
+"""
+
+import json
+
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QTableWidget, QPushButton, QTableWidgetItem, \
+    QMessageBox, QComboBox
+
+
+class XPConfigDialog(QDialog):
+
+    # Add a class attribute to store the priority values
+    PRIORITY_T = ["H", "M","L"]
+
+    def __init__(self, config_file):
+        super().__init__()
+        self.setWindowTitle("Edit XP Configuration")
+        self.config_file = config_file
+        self.config: dict[str, any] = self.load_config()
+
+        # Layout
+        layout = QVBoxLayout(self)
+
+        # Table for priorities
+        self.priority_table = QTableWidget(len(self.config['priorities']), 2)
+        self.priority_table.setHorizontalHeaderLabels(["Priority", "XP"])
+        layout.addWidget(self.priority_table)
+
+        # Populate table from config
+        for row, (priority, xp) in enumerate(self.config['priorities'].items()):
+            priority_dropdown = QComboBox() # Create a dropdown for the priority
+            priority_dropdown.addItems(self.PRIORITY_T) # Add the priority values to the dropdown
+            priority_dropdown.setCurrentText(priority) # Set the current text to the priority
+            priority_dropdown.setDisabled(True) # Disable editing of priority
+
+            self.priority_table.setCellWidget(row, 0, priority_dropdown) # Set the priority cell
+            self.priority_table.setItem(row, 1, QTableWidgetItem(str(xp))) # Set the xp cell
+
+        # Table for tags
+        self.tag_table = QTableWidget(len(self.config['tags']), 2)
+        self.tag_table.setHorizontalHeaderLabels(["Tag", "XP"])
+        layout.addWidget(self.tag_table)
+
+        for row, (tag, xp) in enumerate(self.config['tags'].items()):
+            self.tag_table.setItem(row, 0, QTableWidgetItem(tag))
+            self.tag_table.setItem(row, 1, QTableWidgetItem(str(xp)))
+
+        add_tag_button = QPushButton("Add Tag")
+        add_tag_button.clicked.connect(self.add_tag_row)
+        layout.addWidget(add_tag_button)
+
+        # Save button
+        save_button = QPushButton("Save")
+        save_button.clicked.connect(self.save_config)
+        layout.addWidget(save_button)
+
+    def load_config(self):
+        """
+        Loads configuration data from a file into a dictionary attribute.
+
+        This method reads a JSON formatted configuration file specified by the
+        `config_file` attribute and populates the `config` attribute with the
+        parsed content.
+
+        Raises:
+            FileNotFoundError: If the configuration file does not exist.
+            json.JSONDecodeError: If the configuration file's contents are not
+                valid JSON.
+        """
+        try:
+            with open(self.config_file, 'r') as file:
+                return json.load(file)
+        except (FileNotFoundError, json.JSONDecodeError):
+            # return some arbitrary default config if the file doesn't exist
+            return {"priorities": {'H': 10, 'M': 5, 'L': 1}, "tags": {}}
+
+
+    def save_config(self):
+        # Save table data back to the config file
+        priorities = {}
+        for row in range(self.priority_table.rowCount()):
+            # assign a variable `priority` to the current text of the priority dropdown
+            priority = self.priority_table.cellWidget(row, 0).currentText()
+            xp = int(self.priority_table.item(row, 1).text())
+            priorities[priority] = xp
+        #TODO: we will eventually need to figure out what
+
+        self.config['priorities'] = priorities
+        with open(self.config_file, 'w') as file:
+            json.dump(self.config, file)
+
+        QMessageBox.information(self, "Success", "Configuration saved!", QMessageBox.StandardButtons.Ok)
+
+    def add_tag_row(self):
+        """
+        Inserts a new row into the tag table with two empty cells.
+
+        The method dynamically determines the current number of rows in the
+        tag_table, appends one additional row, and initializes the first two
+        columns of the newly inserted row with empty QTableWidgetItem objects.
+
+        Raises
+        ------
+        TypeError
+            If the tag_table is not properly instantiated or configured.
+        """
+        row_position = self.tag_table.rowCount()
+        self.tag_table.insertRow(row_position)
+        self.tag_table.setItem(row_position, 0, QTableWidgetItem(""))
+        self.tag_table.setItem(row_position, 1, QTableWidgetItem(""))

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -4,9 +4,9 @@
  *  Inputs: None
  *  Outputs: None
  *  Additional code sources: None
- *  Developers: Mo Morgan
+ *  Developers: Mo Morgan, Ethan Berkley
  *  Date: 2/15/2025
- *  Last Modified: 2/28/2025
+ *  Last Modified: 3/2/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: FileNotFoundError: if the configuration file does not exist, json.JSONDecodeError:
@@ -54,18 +54,35 @@ class XPConfigDialog(QDialog):
             self.priority_table.setItem(row, 0, QTableWidgetItem(priority))
             self.priority_table.setItem(row, 1, QTableWidgetItem(str(xp)))
 
-            # Table for tags
-            self.tag_table = QTableWidget(len(self.config['tags']), 2)
-            self.tag_table.setHorizontalHeaderLabels(["Tag", "XP"])
-            layout.addWidget(self.tag_table)
+        # Table for editing tag xp values
+        self.tag_table = QTableWidget(len(self.config['tags']), 2)
+        self.tag_table.setHorizontalHeaderLabels(["Tag", "XP"])
+        layout.addWidget(self.tag_table)
 
+       # Populate tag table using file
         for row, (tag, xp) in enumerate(self.config['tags'].items()):
             self.tag_table.setItem(row, 0, QTableWidgetItem(tag))
             self.tag_table.setItem(row, 1, QTableWidgetItem(str(xp)))
 
+        # Table for editing project xp values
+        self.project_table = QTableWidget(len(self.config['projects']), 2)
+        self.project_table.setHorizontalHeaderLabels(["Project", "XP"])
+        layout.addWidget(self.project_table)
+
+        # Populate project table using file
+        for row, (project, xp) in enumerate(self.config['projects'].items()):
+            self.project_table.setItem(row, 0, QTableWidgetItem(project))
+            self.project_table.setItem(row, 1, QTableWidgetItem(str(xp)))
+
+        # Add tag button
         add_tag_button = QPushButton("Add Tag")
         add_tag_button.clicked.connect(self.add_tag_row)
         layout.addWidget(add_tag_button)
+
+        # Add project button
+        add_project_button = QPushButton("Add Project")
+        add_project_button.clicked.connect(self.add_project_row)
+        layout.addWidget(add_project_button)
 
         # Save button
         save_button = QPushButton("Save")
@@ -90,26 +107,32 @@ class XPConfigDialog(QDialog):
                 return json.load(file)
         except (FileNotFoundError, json.JSONDecodeError):
             # return some arbitrary default config if the file doesn't exist
-            return {"priorities": {'H': 10, 'M': 5, 'L': 1}, "tags": {}}
+            return {"priorities": {'H': 10, 'M': 5, 'L': 1}, "tags": {}, "projects": {}}
 
 
     def save_config(self):
         # Save table data back to the config file
         priorities = {}
         tags = {}
+        projects = {}
         for row in range(self.priority_table.rowCount()):
             priority = self.priority_table.item(row, 0).text()
             xp = int(self.priority_table.item(row, 1).text())
             priorities[priority] = xp
-        #TODO: we will eventually need to figure out what
 
         for row in range(self.tag_table.rowCount()):
             tag = self.tag_table.item(row, 0).text()
             xp = int(self.tag_table.item(row, 1).text())
             tags[tag] = xp
+
+        for row in range(self.project_table.rowCount()):
+            project = self.project_table.item(row, 0).text()
+            xp = int(self.project_table.item(row, 1).text())
+            projects[project] = xp
             
         self.config['priorities'] = priorities # Update the priorities
         self.config['tags'] = tags
+        self.config['projects'] = projects
 
         # Tell XpControllerWidget to update stuff.
         self.xp_values_updated.emit(self.config)
@@ -136,4 +159,15 @@ class XPConfigDialog(QDialog):
         self.tag_table.insertRow(row_position)
         self.tag_table.setItem(row_position, 0, QTableWidgetItem(""))
         self.tag_table.setItem(row_position, 1, QTableWidgetItem(""))
+
+    def add_project_row(self):
+        """
+        Adds a new row to the project table within the Config menu. Each added row will have two
+        empty cells initialized in the newly created row. The row is appended
+        at the current count of rows in the table.
+        """
+        row_position = self.project_table.rowCount()
+        self.project_table.insertRow(row_position)
+        self.project_table.setItem(row_position, 0, QTableWidgetItem(""))
+        self.project_table.setItem(row_position, 1, QTableWidgetItem(""))
 

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -21,19 +21,21 @@ import json
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QTableWidget, QPushButton, QTableWidgetItem, \
     QMessageBox, QComboBox
 from PySide6.QtCore import Signal
-
+from typing import Any
+import os
 
 class XPConfigDialog(QDialog):
 
     # Add a class attribute to store the priority values
-    PRIORITY_T = ["H", "M","L"]
+    PRIORITY_T = ["H", "M", "L"]
     xp_values_updated = Signal(dict) # Signal to indicate that the XP values have been updated
 
     def __init__(self, config_file="components/config/user_defined_xp.json"):
         super().__init__()
+        os.makedirs('components/config/', exist_ok=True)
         self.setWindowTitle("Edit XP Configuration")
         self.config_file = config_file
-        self.config: dict[str, any] = self.load_config()
+        self.config: dict[str, Any] = self.load_config()
 
         # Layout
         layout = QVBoxLayout(self)
@@ -94,14 +96,21 @@ class XPConfigDialog(QDialog):
     def save_config(self):
         # Save table data back to the config file
         priorities = {}
+        tags = {}
         for row in range(self.priority_table.rowCount()):
             priority = self.priority_table.item(row, 0).text()
             xp = int(self.priority_table.item(row, 1).text())
             priorities[priority] = xp
         #TODO: we will eventually need to figure out what
 
-
+        for row in range(self.tag_table.rowCount()):
+            tag = self.tag_table.item(row, 0).text()
+            xp = int(self.tag_table.item(row, 1).text())
+            tags[tag] = xp
+            
         self.config['priorities'] = priorities # Update the priorities
+        self.config['tags'] = tags
+
         self.update_xp_values() # Update the XP values
 
         with open(self.config_file, 'w') as file:

--- a/components/GUI/task_champion_widget.py
+++ b/components/GUI/task_champion_widget.py
@@ -20,7 +20,7 @@ from components.Dialogs.add_task_dialog import AddTaskDialog
 from components.GUI.grid_widget import GridWidget
 from components.GUI.xp_controller_widget import XpControllerWidget
 from components.GUI.menubar import MenuBar
-from utils.task_api import TaskAPI
+from utils.task_api import api
 from typing import Callable
 
 class TaskChampionWidget(QtWidgets.QWidget):
@@ -73,7 +73,7 @@ class TaskChampionWidget(QtWidgets.QWidget):
         if new_task_details is None:  # If the new task details are None.
             return  # Return.
 
-        TaskAPI.add_new_task(
+        api.add_new_task(
             description = new_task_details.description, 
             tags        = new_task_details.tag,
             priority    = new_task_details.priority,

--- a/components/GUI/task_champion_widget.py
+++ b/components/GUI/task_champion_widget.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 2/23/2025
+ *  Last Modified: 3/2/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None

--- a/components/GUI/task_champion_widget.py
+++ b/components/GUI/task_champion_widget.py
@@ -75,7 +75,7 @@ class TaskChampionWidget(QtWidgets.QWidget):
 
         api.add_new_task(
             description = new_task_details.description, 
-            tags        = new_task_details.tag,
+            tags        = new_task_details.tag.split(),
             priority    = new_task_details.priority,
             project     = new_task_details.project,
             recur       = new_task_details.recurrence,

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 2/27/2025
+ *  Last Modified: 2/28/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -47,21 +47,21 @@ class TaskRow:
         self.delete_button = ButtonBox(row_num, self.get_task, "delete", self.delete_task)
 
         # Initial fetch of function calls
-        if self.task != None:
+        if self.task is not None:
             self._bind_xp_fns(self.fetch_xp_brs(self.task))
 
     def get_task(self): return self.task
 
-    def insert(self, grid: QtWidgets.QGridLayout, rowNum: int):
+    def insert(self, grid: QtWidgets.QGridLayout, row_num: int):
         # Row stretch of 0 means take up bare minimum amount of space?
-        grid.setRowStretch(rowNum, 0)
-        grid.addWidget(self.check, rowNum, 0)
+        grid.setRowStretch(row_num, 0)
+        grid.addWidget(self.check, row_num, 0)
         
         for i in range(len(self.cols)):
-            grid.addWidget(self.cols[i], rowNum, i + 1)
+            grid.addWidget(self.cols[i], row_num, i + 1)
 
-        grid.addWidget(self.edit_button, rowNum, len(self.cols) + 1)  # add the edit button to the grid
-        grid.addWidget(self.delete_button, rowNum, len(self.cols) + 2)  # add the delete button to the grid
+        grid.addWidget(self.edit_button, row_num, len(self.cols) + 1)  # add the edit button to the grid
+        grid.addWidget(self.delete_button, row_num, len(self.cols) + 2)  # add the delete button to the grid
 
     def update_task(self):
         self.task = api.task_at(self.idx)
@@ -72,7 +72,7 @@ class TaskRow:
         self.edit_button.update_task()
         self.delete_button.update_task()
 
-        if self.task != None:
+        if self.task is not None:
             self._bind_xp_fns(self.fetch_xp_brs(self.task))
     
     def edit_task(self):
@@ -130,7 +130,7 @@ class TaskRow:
             self.xp_sub_calls.append(xp_bar.sub_xp)
     
     def _update_xp_bars(self, checkbox_state : bool) -> None:
-        if self.task == None:
+        if self.task is None:
             return
 
         completion_value : int = get_completion_value(self.task.get_priority(), self.task.get_project(), self.task.get_tags())

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -16,7 +16,7 @@
 """
 
 from PySide6 import QtWidgets
-from components.GUI.xp_controller_widget import get_completion_value
+from components.GUI.xp_controller_widget import XpControllerWidget
 from utils.task import Task
 from utils.task_api import api
 from components.GUI.checkbox import Checkbox
@@ -133,7 +133,7 @@ class TaskRow:
         if self.task is None:
             return
 
-        completion_value : int = get_completion_value(self.task.get_priority(), self.task.get_project(), self.task.get_tags())
+        completion_value : int = XpControllerWidget.get_completion_value(self.task.get_priority(), self.task.get_project(), self.task.get_tags())
 
         if checkbox_state:
             for add_fn in self.xp_add_calls:

--- a/components/GUI/xp_bar.py
+++ b/components/GUI/xp_bar.py
@@ -51,7 +51,7 @@ class XpBar(QtWidgets.QWidget):
 
     def set_max_xp(self, val: int):
         if val == 0:
-            raise ValueError("Cannot set max xp to 0.")
+            val += 1 # prevents division by zero
         self.xp_bar.set_max_xp(val)
         self.update_text()
 
@@ -101,16 +101,49 @@ class XpBar(QtWidgets.QWidget):
         self.xp_bar._sub_xp(val)
     
     def reset_xp(self) -> None:
+        """
+        Resets the experience points (XP) of the user.
+
+        This method resets the current XP by subtracting it from the XP bar, sets
+        the XP bar's value to zero, and updates the current XP to zero. It is
+        used to initialize or reset a user's progress.
+
+        Raises:
+            None
+        """
         self.xp_bar._sub_xp(self.cur_xp)
         self.xp_bar.setValue(0)
         self.cur_xp = 0
 
     def update_xp(self) -> None:
+        """
+        Updates the experience points (XP) for the current object based on the
+        tasks from the TaskAPI. This includes calculating the maximum possible
+        XP from relevant tasks and the amount of XP gained from completed tasks.
+        Relevance of tasks is determined by comparing their attributes such as
+        priority, project, and tags with the current object's attributes.
+
+        Attributes
+        ----------
+        xp_poss : int
+            Represents the total potential XP that can be gained from all relevant
+            tasks.
+        xp_gain : int
+            Represents the actual XP gained from tasks that are completed.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
         xp_poss : int = 0
         xp_gain : int = 0
 
         # calculate all tasks relevant to set the max_xp value.
-        for i in range(0, TaskAPI.num_tasks()):
+        for i in range(0, TaskAPI.num_tasks(self)):
             task : Task = TaskAPI.task_at(i)
 
             if task is None:

--- a/components/GUI/xp_bar.py
+++ b/components/GUI/xp_bar.py
@@ -1,6 +1,6 @@
 from PySide6 import QtCore, QtWidgets
 
-from utils.task_api import TaskAPI
+from utils.task_api import api
 from utils.task import Task, priority_t
 
 class XpBar(QtWidgets.QWidget):
@@ -143,8 +143,8 @@ class XpBar(QtWidgets.QWidget):
         xp_gain : int = 0
 
         # calculate all tasks relevant to set the max_xp value.
-        for i in range(0, TaskAPI.num_tasks(self)):
-            task : Task = TaskAPI.task_at(i)
+        for i in range(0, api.num_tasks()):
+            task : Task = api.task_at(i)
 
             if task is None:
                 continue
@@ -160,7 +160,6 @@ class XpBar(QtWidgets.QWidget):
         
         self.set_max_xp(xp_poss)
         self.add_xp(xp_gain)
-            
 
 class XpBarChild(QtWidgets.QProgressBar):
     """Class representing an XP Bar. 

--- a/components/GUI/xp_bar.py
+++ b/components/GUI/xp_bar.py
@@ -143,6 +143,8 @@ class XpBar(QtWidgets.QWidget):
         xp_gain : int = 0
 
         # calculate all tasks relevant to set the max_xp value.
+        for i in range(0, api.num_tasks(self)):
+            task : Task = api.task_at(i)
         for i in range(0, api.num_tasks()):
             task : Task = api.task_at(i)
 

--- a/components/GUI/xp_bar.py
+++ b/components/GUI/xp_bar.py
@@ -162,33 +162,30 @@ class XpBarChild(QtWidgets.QProgressBar):
 
     
     def _add_xp(self, val: int) -> None:
-        """returns how many levels we just gained."""
-        
+        self.animation.stop()
         adjusted = val * self.multiplier
-        self.animation.setStartValue(self.adjusted_value)
-
+        
         self.adjusted_value += adjusted
         
         while self.adjusted_value >= self.MAX_VAL:
             self.adjusted_value -= 0.1
         
         self.adjusted_value %= self.MAX_VAL
-
-        self.animation.setEndValue(self.adjusted_value)
+        self.animation.setStartValue(self.value())
+        self.animation.setEndValue(int(self.adjusted_value))
         self.animation.start()
 
     def _sub_xp(self, val : int) -> None:
-        """Returns how many levels we just lost."""
-
+        self.animation.stop()
         adjusted = val * self.multiplier
-        self.animation.setStartValue(self.adjusted_value)
-
+        
         self.adjusted_value -= adjusted
 
         while self.adjusted_value <= 0:
             self.adjusted_value += 0.1
         
         self.adjusted_value %= self.MAX_VAL
-
-        self.animation.setEndValue(self.adjusted_value)
+        self.animation.setStartValue(self.value())
+        self.animation.setEndValue(int(self.adjusted_value))
         self.animation.start()
+        

--- a/components/GUI/xp_bar.py
+++ b/components/GUI/xp_bar.py
@@ -79,7 +79,19 @@ class XpBar(QtWidgets.QWidget):
         self.sub_xp(self.completion_value)
         
     def add_xp(self, val : int) -> None:
-        self.cur_xp = (self.cur_xp + val) % self.xp_bar.max_xp if self.xp_bar.max_xp != 0 else 1    
+        """
+        Increments the current experience (XP) value with the provided input and updates
+        the associated XP bar and text display. If the maximum XP in the XP bar is non-zero,
+        the method calculates the new XP by wrapping its value around the maximum XP.
+        Otherwise, a default value of 1 is set for the XP.
+
+        Args:
+            val (int): The amount of experience to be added.
+
+        Returns:
+            None
+        """
+        self.cur_xp = (self.cur_xp + val) % self.xp_bar.max_xp if self.xp_bar.max_xp != 0 else 1
         self.update_text()
         self.xp_bar._add_xp(val)
     

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -1,3 +1,20 @@
+"""
+ *  Module Name: xp_controller_widget.py
+ *  Purpose: Defines the XP controller widget, which manages the display of XP bars
+ *  Inputs: None
+ *  Outputs: None
+ *  Additional code sources: None
+ *  Developers: Mo Morgan
+ *  Date: 2/26/2025
+ *  Last Modified: 2/28/2025
+ *  Preconditions: None
+ *  Postconditions: None
+ *  Error/Exception conditions:
+ *  Side effects: None
+ *  Invariants: None
+ *  Known Faults: None encountered
+"""
+
 from components.GUI.xp_bar import XpBar
 from PySide6 import QtWidgets
 from utils.task import priority_t, Task
@@ -37,6 +54,23 @@ class XpControllerWidget(QtWidgets.QWidget):
         self.setLayout(self.main_layout)
     
     def add_xp_bar(self, task : Task, max_xp : int, title : str) -> None:
+        """
+        Adds a new XP bar for a specific task to the user interface. The XP bar visually
+        represents the progress of a task based on its completion value, maximum XP,
+        and associated attributes like priority, project, and tags.
+
+        Parameters:
+        task : Task
+            The task object containing details like priority, project, and tags
+            used to determine the XP bar's attributes.
+        max_xp : int
+            The maximum XP value that the XP bar can display.
+        title : str
+            The title of the XP bar, which is displayed as a label.
+
+        Returns:
+        None
+        """
         completion_value : int = get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
 
         new_xp_bar = XpBar(self, completion_value)
@@ -50,6 +84,22 @@ class XpControllerWidget(QtWidgets.QWidget):
         self.main_layout.addWidget(new_xp_bar)
     
     def get_relevant_xp_bars(self, task : Task) -> list[XpBar]:
+        """
+        Retrieves experience bars relevant to the provided task based on task attributes,
+        matching priority, project, or tags. The function also includes the main experience
+        bar in the returned list.
+
+        Parameters:
+
+        task : Task
+            The task object containing attributes that determine relevance to
+            experience bars.
+
+        Returns:
+        list[XpBar]
+            A list of experience bars relevant to the task. This includes any matching bars
+            based on priority, project, or tags, as well as the main experience bar.
+        """
         bars_to_return = []
 
         for bar in self.xp_bars:

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -19,6 +19,7 @@ from components.GUI.xp_bar import XpBar
 from PySide6 import QtWidgets
 from utils.task import priority_t, Task
 from utils.task_api import api
+from components.Dialogs.define_xp_dialog import XPConfigDialog
 
 PRIORITY_MULT_MAP : dict[priority_t, int] = { 'H':3, 'M':2, 'L':1 }
 PROJECT_MULT_MAP : dict[str, int] = {}
@@ -52,6 +53,9 @@ class XpControllerWidget(QtWidgets.QWidget):
         self.xp_bars.append(self.main_xp_bar)
 
         self.setLayout(self.main_layout)
+
+        self.xp_config_dialog = XPConfigDialog()
+        self.xp_config_dialog.xp_values_updated.connect(self.update_priority_mult_map)
     
     def add_xp_bar(self, task : Task, max_xp : int, title : str) -> None:
         """
@@ -73,7 +77,7 @@ class XpControllerWidget(QtWidgets.QWidget):
         """
         completion_value : int = get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
 
-        new_xp_bar = XpBar(self, completion_value)
+        new_xp_bar = XpBar(completion_value)
         new_xp_bar.set_max_xp(max_xp)
         new_xp_bar.set_attributes(task.get_priority(), task.get_project(), task.get_tags())
 
@@ -133,9 +137,22 @@ class XpControllerWidget(QtWidgets.QWidget):
                 continue
             
             completion_value : int = get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
-
+            print(completion_value)
             xp_poss += completion_value
             xp_gain += completion_value if task.get_status() == "completed" else 0
         
         self.main_xp_bar.set_max_xp(xp_poss)
         self.main_xp_bar.add_xp(xp_gain)
+
+    def update_priority_mult_map(self, updated_values: dict):
+        """
+        Updates the priority multiplier map with the provided values from the XP configuration dialog.
+
+        Parameters:
+        updated_values : dict
+            A dictionary containing updated priority multiplier values.
+        """
+        global PRIORITY_MULT_MAP
+        PRIORITY_MULT_MAP = updated_values
+        self.update_bars()    # update the XP bars to reflect the new values. This functionality may not be wanted.
+                                # Discuss in PR

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -31,6 +31,33 @@ class XpControllerWidget(QtWidgets.QWidget):
     @staticmethod
     def get_completion_value(priority : priority_t, project : str | None, tags : list[str] | None) -> int:
         completion_value : int = XpControllerWidget.PRIORITY_MULT_MAP[priority]
+    def get_completion_value(priority : priority_t, project : str | None, tags : list[str] | None) -> int:
+        """
+        Determine the completion value based on priority, project, and tags.
+
+        This function calculates a completion value utilizing multipliers found in
+        pre-defined maps. The base value is retrieved using the provided priority
+        and is potentially adjusted based on the existence and matching of the
+        project and tags in their respective multiplier maps.
+
+        Parameters
+        ----------
+        priority : priority_t
+            The priority level used to determine the base completion value.
+        project : str | None
+            The associated project name, if any, used to adjust the completion
+            value. If the project matches one in the project multiplier map,
+            the value is adjusted accordingly.
+        tags : list[str] | None
+            A list of tags that, if present in the tag multiplier map, are used
+            to further modify the completion value.
+
+        Returns
+        -------
+        int
+            The computed completion value after applying all relevant multipliers.
+        """
+        completion_value : int = XpControllerWidget.PRIORITY_MULT_MAP[priority]
 
         if project in XpControllerWidget.PROJECT_MULT_MAP:
             completion_value *= XpControllerWidget.PROJECT_MULT_MAP[project]
@@ -39,7 +66,7 @@ class XpControllerWidget(QtWidgets.QWidget):
             for tag in tags:
                 if tag in XpControllerWidget.TAG_MULT_MAP:
                     completion_value *= XpControllerWidget.TAG_MULT_MAP[tag]
-        
+
         return completion_value
 
     def __init__(self):
@@ -128,7 +155,7 @@ class XpControllerWidget(QtWidgets.QWidget):
             # update the xp of all bars but the main xp bar
             if bar != self.main_xp_bar:
                 bar.update_xp()
-            
+
 
         xp_poss : int = 0
         xp_gain : int = 0

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -49,6 +49,10 @@ class XpControllerWidget(QtWidgets.QWidget):
         self.xp_bars : list[XpBar] = []
         self.main_layout = QtWidgets.QVBoxLayout()
 
+        self.config_button = QtWidgets.QPushButton('Config')
+        self.config_button.pressed.connect(self.popup_xp_config)
+        self.main_layout.addWidget(self.config_button)
+
         self.main_xp_bar = XpBar(self)
         self.main_xp_bar.set_max_xp(5)
         self.main_layout.addWidget(self.main_xp_bar)
@@ -58,7 +62,8 @@ class XpControllerWidget(QtWidgets.QWidget):
 
         self.xp_config_dialog = XPConfigDialog()
         self.xp_config_dialog.xp_values_updated.connect(self.update_priority_mult_map)
-    
+        self.update_priority_mult_map(self.xp_config_dialog.config)
+        
     def add_xp_bar(self, task : Task, max_xp : int, title : str) -> None:
         """
         Adds a new XP bar for a specific task to the user interface. The XP bar visually
@@ -128,7 +133,6 @@ class XpControllerWidget(QtWidgets.QWidget):
             # update the xp of all bars but the main xp bar
             if bar != self.main_xp_bar:
                 bar.update_xp()
-            
 
         xp_poss : int = 0
         xp_gain : int = 0
@@ -147,6 +151,9 @@ class XpControllerWidget(QtWidgets.QWidget):
         self.main_xp_bar.set_max_xp(xp_poss)
         self.main_xp_bar.add_xp(xp_gain)
 
+    def popup_xp_config(self):
+        self.xp_config_dialog.exec()
+        
     def update_priority_mult_map(self, updated_values: dict):
         """
         Updates the priority multiplier map with the provided values from the XP configuration dialog.
@@ -155,7 +162,9 @@ class XpControllerWidget(QtWidgets.QWidget):
         updated_values : dict
             A dictionary containing updated priority multiplier values.
         """
-
-        self.PRIORITY_MULT_MAP = updated_values
+        
+        XpControllerWidget.PRIORITY_MULT_MAP = updated_values['priorities']
+        XpControllerWidget.TAG_MULT_MAP = updated_values['tags']
+        
         self.update_bars()    # update the XP bars to reflect the new values. This functionality may not be wanted.
                                 # Discuss in PR

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -4,8 +4,8 @@
  *  Inputs: None
  *  Outputs: None
  *  Additional code sources: None
- *  Developers: Mo Morgan
- *  Date: 2/26/2025
+ *  Developers: Jacob Wilkus, Mo Morgan
+ *  Date: 2/25/2025
  *  Last Modified: 2/28/2025
  *  Preconditions: None
  *  Postconditions: None

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -21,24 +21,26 @@ from utils.task import priority_t, Task
 from utils.task_api import api
 from components.Dialogs.define_xp_dialog import XPConfigDialog
 
-PRIORITY_MULT_MAP : dict[priority_t, int] = { 'H':3, 'M':2, 'L':1 }
-PROJECT_MULT_MAP : dict[str, int] = {}
-TAG_MULT_MAP : dict[str, int] = {}
 
-def get_completion_value(priority : priority_t, project : str | None, tags : list[str] | None) -> int:
-    completion_value : int = PRIORITY_MULT_MAP[priority]
-
-    if project in PROJECT_MULT_MAP:
-        completion_value *= PROJECT_MULT_MAP[project]
-
-    if tags is not None:
-        for tag in tags:
-            if tag in TAG_MULT_MAP:
-                completion_value *= TAG_MULT_MAP[tag]
-    
-    return completion_value
 
 class XpControllerWidget(QtWidgets.QWidget):
+    PRIORITY_MULT_MAP : dict[priority_t, int] = { 'H':3, 'M':2, 'L':1 }
+    PROJECT_MULT_MAP : dict[str, int] = {}
+    TAG_MULT_MAP : dict[str, int] = {}
+
+    @staticmethod
+    def get_completion_value(priority : priority_t, project : str | None, tags : list[str] | None) -> int:
+        completion_value : int = XpControllerWidget.PRIORITY_MULT_MAP[priority]
+
+        if project in XpControllerWidget.PROJECT_MULT_MAP:
+            completion_value *= XpControllerWidget.PROJECT_MULT_MAP[project]
+
+        if tags is not None:
+            for tag in tags:
+                if tag in XpControllerWidget.TAG_MULT_MAP:
+                    completion_value *= XpControllerWidget.TAG_MULT_MAP[tag]
+        
+        return completion_value
 
     def __init__(self):
         super().__init__()
@@ -75,7 +77,7 @@ class XpControllerWidget(QtWidgets.QWidget):
         Returns:
         None
         """
-        completion_value : int = get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
+        completion_value : int = self.get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
 
         new_xp_bar = XpBar(completion_value)
         new_xp_bar.set_max_xp(max_xp)
@@ -126,6 +128,7 @@ class XpControllerWidget(QtWidgets.QWidget):
             # update the xp of all bars but the main xp bar
             if bar != self.main_xp_bar:
                 bar.update_xp()
+            
 
         xp_poss : int = 0
         xp_gain : int = 0
@@ -136,7 +139,7 @@ class XpControllerWidget(QtWidgets.QWidget):
             if task is None:
                 continue
             
-            completion_value : int = get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
+            completion_value : int = self.get_completion_value(task.get_priority(), task.get_project(), task.get_tags())
             print(completion_value)
             xp_poss += completion_value
             xp_gain += completion_value if task.get_status() == "completed" else 0
@@ -152,7 +155,7 @@ class XpControllerWidget(QtWidgets.QWidget):
         updated_values : dict
             A dictionary containing updated priority multiplier values.
         """
-        global PRIORITY_MULT_MAP
-        PRIORITY_MULT_MAP = updated_values
+
+        self.PRIORITY_MULT_MAP = updated_values
         self.update_bars()    # update the XP bars to reflect the new values. This functionality may not be wanted.
                                 # Discuss in PR

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -29,7 +29,7 @@ class XpControllerWidget(QtWidgets.QWidget):
     TAG_MULT_MAP : dict[str, int] = {}
 
     @staticmethod
-    def get_completion_value(priority : priority_t, project : str | None, tags : list[str] | None) -> int:
+    def get_completion_value(priority : priority_t, projects : list[str] | None, tags : list[str] | None) -> int:
         """
         Determine the completion value based on priority, project, and tags.
 
@@ -42,7 +42,7 @@ class XpControllerWidget(QtWidgets.QWidget):
         ----------
         priority : priority_t
             The priority level used to determine the base completion value.
-        project : str | None
+        projects : str | None
             The associated project name, if any, used to adjust the completion
             value. If the project matches one in the project multiplier map,
             the value is adjusted accordingly.
@@ -57,8 +57,10 @@ class XpControllerWidget(QtWidgets.QWidget):
         """
         completion_value : int = XpControllerWidget.PRIORITY_MULT_MAP[priority]
 
-        if project in XpControllerWidget.PROJECT_MULT_MAP:
-            completion_value *= XpControllerWidget.PROJECT_MULT_MAP[project]
+        if projects is not None:
+            for project in projects:
+                if project in XpControllerWidget.PROJECT_MULT_MAP:
+                    completion_value *= XpControllerWidget.PROJECT_MULT_MAP[project]
 
         if tags is not None:
             for tag in tags:
@@ -189,6 +191,7 @@ class XpControllerWidget(QtWidgets.QWidget):
         
         XpControllerWidget.PRIORITY_MULT_MAP = updated_values['priorities']
         XpControllerWidget.TAG_MULT_MAP = updated_values['tags']
+        XpControllerWidget.PROJECT_MULT_MAP_MULT_MAP = updated_values['projects']
         
         self.update_bars()    # update the XP bars to reflect the new values. This functionality may not be wanted.
                                 # Discuss in PR

--- a/utils/task_api.py
+++ b/utils/task_api.py
@@ -30,6 +30,7 @@ class TaskAPI:
         self.task_list: list[Task] = []
 
         self._init_task_list()
+        
     def _init_task_list(self) -> None:
         k, r = self._get_sort_params(self.sort_metric)
         self.task_list.sort(key=k, reverse=r)


### PR DESCRIPTION
This PR closes #17.

This pull request implements several features related to XP configuration and tracking as outlined in the requirements. The following features have been added:

**Define XP Earned from Projects, Priorities, etc. (Requirement 4.3)**
Users can now define how much XP is earned from a given project, priority, or tag through the `XPConfigDialog`.
The `get_completion_value` function has been updated to calculate the completion value based on the defined multipliers.


**Add Multiple Progress Bars (Requirement 4.5)**
Users can add more than one progress bar to track different tasks.
The `add_xp_bar` method in `XpControllerWidget` allows adding new XP bars for specific tasks.

**Save XP Earned Locally (Requirement 4.7)**
The XP earned is saved locally and loaded upon startup.
The update_bars method in XpControllerWidget recalculates and updates the XP bars based on the saved data.

**Save XP Weights Locally (Requirement 4.8)**
The XP weights for projects, priorities, and tags are saved locally and loaded upon startup.
The update_priority_mult_map method updates the global `PRIORITY_MULT_MAP`, `PROJECT_MULT_MAP`, and `TAG_MULT_MAP `dictionaries with the saved values.

**Build Baseline Progress Bar if Save File Does Not Exist (Requirement 4.9)**
If the save file does not exist, a baseline progress bar is automatically built based on the user's completed tasks.
The `update_bars` method ensures that the main XP bar is set up with the appropriate max XP and current XP values.

**_Code Changes_**
**XP Configuration Dialog (XPConfigDialog)**
Added methods to save and load XP configuration.
Updated the `save_config` method to call update_xp_values.

**XP Controller Widget (XpControllerWidget)**
Added methods to add XP bars and update them based on the saved configuration.
Implemented the `update_priority_mult_map` method to update the XP multipliers.

**Task Completion Value Calculation**
Updated the `get_completion_value` function to use the updated XP multipliers.

**Local Storage**
Implemented methods to save and load XP data and configuration from local files.

**Known Errors/Areas for Future Work**
* When any tasks are deleted and a task as added after the deletion, a `RuntimeError` is thrown. The message of the error says _"Internal C++ Object (Checkbox) already deleted"_. I believe this is due to the logic for deleting task rows deletes the actual row - I'm not sure if this was accidentally reverted during the sprint or if the delete refactor hasn't been completed.
* Customized XP values are multiplicative -- we might want them to be additive.
* Can't edit the tags or project of a task via the edit button
* The XP values for the projects attribute aren't being calculated properly.

Video demo: I couldn't record a demo vid that was within the size limit. When you pull down the branch to test, note that:
* You can't open the add task and config menus at the same time
* When you change the XP values for the tags and/or priorities, the total exp of the XP bar adjusts to match the value change
* The points that are assigned to a task are multiplicative i.e. a task that has an XP value of 20 for 'H' priority and 4 for the 'Home' tag will be worth 80 XP.


