### PR TITLE
Feature change showing priority

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest taskw-ng
+          pip install pytest taskw-ng PySide6
           sudo apt-get install taskwarrior
       - name: Initialize Taskwarrior
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,8 +3,8 @@
 # *  Inputs: None
 # *  Outputs: None
 # *  Additional code sources: None
-# *  Developers: Jacob Wilkus
-# *  Date: 2/25/2025
+# *  Developers: Jacob Wilkus, Mo Morgan
+# *  Date: 3/10/2025
 # *  Last Modified: 2/25/2025
 # *  Preconditions: None
 # *  Postconditions: None
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest taskw-ng
+          pip install pytest taskw-ng PySide6
           sudo apt-get install taskwarrior
       - name: Initialize Taskwarrior
         run: |

--- a/api-tests.py
+++ b/api-tests.py
@@ -25,7 +25,7 @@ class TestClass:
     def test_api_add_task(self):
         """Test Adding a basic task to the API"""
         task : dict = api.add_new_task(
-            delete_function = print,
+            delete_function = "print"",
             description = "Test Description",
             tags        = "A",
             priority    = "H",

--- a/api-tests.py
+++ b/api-tests.py
@@ -45,13 +45,13 @@ class TestClass:
         assert task_idx != -1 # test that a task exists. If not, then the test method failed.
 
         task = api.task_at(task_idx)  # get the task at the index
-        assert task != None  # test that the task exists. If not, then the test method failed.
+        assert task is not None  # test that the task exists. If not, then the test method failed.
 
         task.set("description", "New Description")  # set the description of the task
         api.update_task(task)  # update the task in the API
         
         t = api.task_at(task_idx)  # get the task at the index
-        assert t != None  # test that the task exists. If not, then the test method failed.
+        assert t is not None  # test that the task exists. If not, then the test method failed.
         assert t.get_description() == "New Description"  # test if the description is set
     
     def test_api_delete_task(self):

--- a/api-tests.py
+++ b/api-tests.py
@@ -4,8 +4,8 @@
  *  Inputs: None
  *  Outputs: None
  *  Additional code sources: None
- *  Developers: Ethan Berkley, Jacob Wilkus
- *  Date: 2/25/2025
+ *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan
+ *  Date: 3/10/2025
  *  Last Modified: 2/25/2025
  *  Preconditions: None
  *  Postconditions: None
@@ -21,10 +21,11 @@ register_api(TaskAPIImpl) # Order matters.
 from utils.task_api import api
 
 class TestClass:
-    '''Taskwarrior API tests'''
+    """Taskwarrior API tests"""
     def test_api_add_task(self):
-        '''Test Adding a basic task to the API'''
+        """Test Adding a basic task to the API"""
         task : dict = api.add_new_task(
+            delete_function = print,
             description = "Test Description",
             tags        = "A",
             priority    = "H",
@@ -35,9 +36,10 @@ class TestClass:
         assert "A" in task["tags"] # test if the tag is set
         assert task["priority"] == "H" # test if the priority is set
         assert task["project"] == "Test Project" # test if the project is set
+        assert task["function"] == "print"
     
     def test_api_update_task(self):
-        '''Test updating a task in the API'''
+        """Test updating a task in the API"""
 
         task_idx = api.num_tasks() - 1
         assert task_idx != -1 # test that a task exists. If not, then the test method failed.
@@ -53,7 +55,7 @@ class TestClass:
         assert t.get_description() == "New Description"  # test if the description is set
     
     def test_api_delete_task(self):
-        '''Test deleting a task in the API'''
+        """Test deleting a task in the API"""
         task_idx = api.num_tasks() - 1  # get the index of the last task
         assert task_idx != -1 # test that a task exists. If not, then the test method failed.
 

--- a/api-tests.py
+++ b/api-tests.py
@@ -25,7 +25,7 @@ class TestClass:
     def test_api_add_task(self):
         """Test Adding a basic task to the API"""
         task : dict = api.add_new_task(
-            delete_function = "print"",
+            delete_function = "print",
             description = "Test Description",
             tags        = "A",
             priority    = "H",

--- a/api-tests.py
+++ b/api-tests.py
@@ -25,7 +25,7 @@ class TestClass:
     def test_api_add_task(self):
         """Test Adding a basic task to the API"""
         task : dict = api.add_new_task(
-            delete_function = "print",
+            # delete_function = "print",
             description = "Test Description",
             tags        = "A",
             priority    = "H",
@@ -36,7 +36,7 @@ class TestClass:
         assert "A" in task["tags"] # test if the tag is set
         assert task["priority"] == "H" # test if the priority is set
         assert task["project"] == "Test Project" # test if the project is set
-        assert task["function"] == "print"
+        # assert task["function"] == "print"
     
     def test_api_update_task(self):
         """Test updating a task in the API"""

--- a/api-tests.py
+++ b/api-tests.py
@@ -25,7 +25,6 @@ class TestClass:
     def test_api_add_task(self):
         """Test Adding a basic task to the API"""
         task : dict = api.add_new_task(
-            # delete_function = "print",
             description = "Test Description",
             tags        = "A",
             priority    = "H",
@@ -36,8 +35,7 @@ class TestClass:
         assert "A" in task["tags"] # test if the tag is set
         assert task["priority"] == "H" # test if the priority is set
         assert task["project"] == "Test Project" # test if the project is set
-        # assert task["function"] == "print"
-    
+
     def test_api_update_task(self):
         """Test updating a task in the API"""
 

--- a/components/Dialogs/edit_task_dialog.py
+++ b/components/Dialogs/edit_task_dialog.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 2/23/2025
+ *  Last Modified: 3/7/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -15,7 +15,7 @@
  *  Known Faults: None encountered
 """
 
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtWidgets
 
 class EditTaskDialog(QtWidgets.QDialog):
     def __init__(self, description="", due="", priority=""):
@@ -24,7 +24,10 @@ class EditTaskDialog(QtWidgets.QDialog):
 
         self.description_text = QtWidgets.QLineEdit(description)
         self.due_text = QtWidgets.QLineEdit(due)
-        self.priority_text = QtWidgets.QLineEdit(priority)
+
+        self.priority_text = QtWidgets.QComboBox() # Create a combo box for the priority
+        self.priority_text.addItems(["H", "M", "L"]) # Add the priority options to the combo box
+        self.priority_text.setCurrentText(priority) # Set the current text to the priority of the task
 
         self.form.addRow("Description", self.description_text)
         self.form.addRow("Due", self.due_text)
@@ -33,8 +36,6 @@ class EditTaskDialog(QtWidgets.QDialog):
 
         button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
                                       | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
-
-
 
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(self.form)
@@ -60,4 +61,4 @@ class EditTaskDialog(QtWidgets.QDialog):
 
     @property
     def priority(self):
-        return self.priority_text.text()
+        return self.priority_text.currentText()

--- a/components/Dialogs/edit_task_dialog.py
+++ b/components/Dialogs/edit_task_dialog.py
@@ -22,18 +22,26 @@ class EditTaskDialog(QtWidgets.QDialog):
         super().__init__()
         self.form = QtWidgets.QFormLayout()
 
-        self.description_text = QtWidgets.QLineEdit(description)
-        self.due_text = QtWidgets.QDateEdit()
+        self.description_text = QtWidgets.QLineEdit(description) # set the description text to the description of the task
+
+        self.due_date = QtWidgets.QDateEdit() # Create a date edit object for the due date
         # set the due date to the current date + 1 day
-        self.due_text.setDate(self.due_text.date().currentDate().addDays(1))
-        # self.due_text = QtWidgets.QLineEdit(due)
+        self.due_date.setDate(self.due_date.date().currentDate().addDays(1))
+        # and bring up the calendar if the arrow is clicked
+        self.due_date.setCalendarPopup(True)
+        if due:
+            # if the format of `due` isn't yyy-MM-dd, then the date will be set to the current date + 1 day. The user will have
+            # to use the calendar to set the date to the correct one.
+
+            self.due_date.setDate(self.due_date.date().fromString(due, "yyyy-MM-dd"))
+
 
         self.priority_text = QtWidgets.QComboBox() # Create a combo box for the priority
         self.priority_text.addItems(["H", "M", "L"]) # Add the priority options to the combo box
         self.priority_text.setCurrentText(priority) # Set the current text to the priority of the task
 
         self.form.addRow("Description", self.description_text)
-        self.form.addRow("Due", self.due_text)
+        self.form.addRow("Due", self.due_date)
         self.form.addRow("Priority", self.priority_text)
 
 
@@ -60,7 +68,13 @@ class EditTaskDialog(QtWidgets.QDialog):
 
     @property
     def due(self):
-        return self.due_text.text()
+        """
+        Returns the due date of the task as a string in the format 'yyyy-MM-dd'.
+
+         Returns:
+             str: The due date of the task
+             """
+        return self.due_date.date().toString("yyyy-MM-dd")
 
     @property
     def priority(self):

--- a/components/Dialogs/edit_task_dialog.py
+++ b/components/Dialogs/edit_task_dialog.py
@@ -23,7 +23,10 @@ class EditTaskDialog(QtWidgets.QDialog):
         self.form = QtWidgets.QFormLayout()
 
         self.description_text = QtWidgets.QLineEdit(description)
-        self.due_text = QtWidgets.QLineEdit(due)
+        self.due_text = QtWidgets.QDateEdit()
+        # set the due date to the current date + 1 day
+        self.due_text.setDate(self.due_text.date().currentDate().addDays(1))
+        # self.due_text = QtWidgets.QLineEdit(due)
 
         self.priority_text = QtWidgets.QComboBox() # Create a combo box for the priority
         self.priority_text.addItems(["H", "M", "L"]) # Add the priority options to the combo box

--- a/components/Dialogs/edit_task_dialog.py
+++ b/components/Dialogs/edit_task_dialog.py
@@ -37,7 +37,7 @@ class EditTaskDialog(QtWidgets.QDialog):
 
 
         self.priority_text = QtWidgets.QComboBox() # Create a combo box for the priority
-        self.priority_text.addItems(["H", "M", "L"]) # Add the priority options to the combo box
+        self.priority_text.addItems(["None", "H", "M", "L"]) # Add the priority options to the combo box
         self.priority_text.setCurrentText(priority) # Set the current text to the priority of the task
 
         self.form.addRow("Description", self.description_text)
@@ -78,4 +78,7 @@ class EditTaskDialog(QtWidgets.QDialog):
 
     @property
     def priority(self):
+        if self.priority_text.currentText() == "None":
+            return ""
         return self.priority_text.currentText()
+        # return self.priority_text.currentText()

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -24,7 +24,6 @@ from components.GUI.textbox import Textbox
 from components.GUI.buttonbox import ButtonBox
 from components.GUI.xp_bar import XpBar
 from components.Dialogs.edit_task_dialog import EditTaskDialog
-from styles.extra_styles import get_style
 from typing import Callable, Final
 
 # The names of the columns.
@@ -105,7 +104,7 @@ class TaskRow:
 
         if self.task is not None:  # If the task is not None.
             self._bind_xp_fns(self.fetch_xp_brs(self.task))  # Bind the xp functions.
-    
+
     def edit_task(self):
         if not self.task:  # If the task is None.
             return  # Return.
@@ -113,14 +112,14 @@ class TaskRow:
         edit_task_dialog = EditTaskDialog(str(self.task.get("description") or ""),
             str(self.task.get("due") or ""),
             str(self.task.get("priority") or ""))  # Create an instance of the EditTaskDialog class.
-        
+
         if edit_task_dialog.exec():  # If the dialog is executed.
             self.task.set("description", edit_task_dialog.description or None)  # Set the description of the task.
             self.task.set("due", edit_task_dialog.due or None)  # Set the due date of the task.
             self.task.set("priority", edit_task_dialog.priority or None)  # Set the priority of the task.
             api.update_task(self.task)  # Update the task.
             self.update_task()  # Update the task.
-            
+
     def delete_task(self):
         api.delete_at(self.idx)  # Delete the task at the index.
         self.remove_task_row()  # remove the task row from the UI
@@ -130,7 +129,7 @@ class TaskRow:
         grid = self.check.parentWidget().layout()  # Get the layout of the parent widget.
         if not grid:  # If the grid is None.
             return  # Return.
-    
+
         # Loop through the widgets in the row and remove them
         for widget in [self.check] + self.cols + [self.edit_button, self.delete_button]:
             grid.removeWidget(widget)  # Remove the widget from the grid.
@@ -143,7 +142,7 @@ class TaskRow:
         grid = self.check.parentWidget().layout()  # Get the layout of the parent widget.
         if not grid:  # If the grid is None.
             return  # Return.
-    
+
         # Loop through the widgets in the row and remove them
         for widget in [self.check] + self.cols + [self.edit_button, self.delete_button]:  # Loop through the widgets.
             grid.removeWidget(widget)  # Remove the widget from the grid.
@@ -159,7 +158,7 @@ class TaskRow:
         for xp_bar in xp_bars:
             self.xp_add_calls.append(xp_bar.add_xp)  # Append the add xp function.
             self.xp_sub_calls.append(xp_bar.sub_xp)  # Append the sub xp function.
-    
+
     def _update_xp_bars(self, checkbox_state : bool) -> None:
         if self.task is None:  # If the task is None.
             return  # Return.

--- a/utils/task.py
+++ b/utils/task.py
@@ -33,7 +33,10 @@ class Task(task.Task):
         return self['description']  # Return the description field.
 
     def get_due(self) -> fields.DateField:
-        return self['due']  # Return the due field.
+        if 'due' not in self:  # If the due field does not exist
+            return None  # Return None
+        else:  # If the due field exists
+            return self['due']  # Return the due field.
     
     def set_due(self, due : str) -> None:
         self.set('due', due)  # Set the due field to the given due date.

--- a/utils/task_api.py
+++ b/utils/task_api.py
@@ -21,6 +21,7 @@ from utils.sortmetric import SortMetric
 from utils.task import Task
 from typing import Callable, Optional
 import uuid
+from PySide6 import QtCore
 
 class TaskAPI:
     def __init__(self):
@@ -118,8 +119,10 @@ class TaskAPIImpl(TaskAPI):
         
         super()._init_task_list()  # Call the parent init task list method.
     
-    def add_new_task(self, description: str, tags=None, **kw) -> dict:  # Add a new task.
-        task : dict = self.warrior.task_add(description, tags, **kw)  # Add a task.
+    def add_new_task(self, description: str, tags=None, due="", **kw) -> dict:  # Add a new task.
+        if due:
+            due = QtCore.QDate.fromString(due, "yyyy-MM-dd").toString("yyyy-MM-dd")
+        task : dict = self.warrior.task_add(description, tags, due, **kw)  # Add a task.
         self._init_task_list()  # Initialize the task list.
 
         return task  # Return the task.
@@ -138,6 +141,8 @@ class TaskAPIImpl(TaskAPI):
         self.warrior.task_delete(uuid=str(t['uuid']))  # Delete the task.
 
     def update_task(self, new_task: Task) -> None:
+        if new_task.get_due():
+            new_task['due'] = QtCore.QDate.fromString(new_task['due'], "yyyy-MM-dd").toString("yyyy-MM-dd")
         self.warrior.task_update(new_task)  # Update the task.
         self._init_task_list()  # Initialize the task list.
 
@@ -166,6 +171,8 @@ class FakeTaskAPI(TaskAPI):
         return self.task_list[idx]  # Return the task at the index.
     
     def add_new_task(self, description: str = "", tags=None, priority="", project="", recur="", due="") -> dict:
+        if due:
+            due = QtCore.QDate.fromString(due, "yyyy-MM-dd").toString("yyyy-MM-dd")
         d = dict({'uuid': str(uuid.uuid1()), 'id': str(self.cur_id), 'description': description, 'tags': [tags], 'priority': priority, 'project': project, 'recur': recur, 'due': due})
         self.cur_id += 1  # Increment the current ID.
         
@@ -190,6 +197,8 @@ class FakeTaskAPI(TaskAPI):
 
     def update_task(self, new_task: Task) -> None:
         found = False  # Initialize found to False.
+        if new_task.get_due():
+            new_task['due'] = QtCore.QDate.fromString(new_task['due'], "yyyy-MM-dd").toString("yyyy-MM-dd")
         for idx in range(self.num_tasks()):  # For each task.
             if self.task_list[idx].get_uuid() == new_task.get_uuid():  # If the UUIDs match.
                 self.task_list[idx] = new_task  # Update the task.

--- a/utils/task_api.py
+++ b/utils/task_api.py
@@ -122,7 +122,7 @@ class TaskAPIImpl(TaskAPI):
     def add_new_task(self, description: str, tags=None, due="", **kw) -> dict:  # Add a new task.
         if due:
             due = QtCore.QDate.fromString(due, "yyyy-MM-dd").toString("yyyy-MM-dd")
-        task : dict = self.warrior.task_add(description, tags, due, **kw)  # Add a task.
+        task : dict = self.warrior.task_add(description, tags, **kw)  # Add a task.
         self._init_task_list()  # Initialize the task list.
 
         return task  # Return the task.

--- a/utils/task_api.py
+++ b/utils/task_api.py
@@ -141,8 +141,8 @@ class TaskAPIImpl(TaskAPI):
         self.warrior.task_delete(uuid=str(t['uuid']))  # Delete the task.
 
     def update_task(self, new_task: Task) -> None:
-        if new_task.get_due():
-            new_task['due'] = QtCore.QDate.fromString(new_task['due'], "yyyy-MM-dd").toString("yyyy-MM-dd")
+        if new_task.get_due() is not None:  # If the task has a due date.
+            new_task['due'] = QtCore.QDate.fromString(new_task['due'], "yyyy-MM-dd").toString("yyyy-MM-dd")  # Set the due date.
         self.warrior.task_update(new_task)  # Update the task.
         self._init_task_list()  # Initialize the task list.
 


### PR DESCRIPTION
This PR closes #39 

You'll notice when editing tasks that the priority text box has been replaced by a `QComboBox` (a drop-down menu) the user uses to choose the priority of the task:

![image](https://github.com/user-attachments/assets/64bc55a7-4171-43e2-b07b-28d932d82a44)

The value in the priority dropbox defaults to the current priority of the task being edited when the Edit Task window initially opens.

![image](https://github.com/user-attachments/assets/021d692c-8fc3-46c6-9207-ac75fe2035d7)

There was no need to validate the values for description (It changes all input into a str) and priority (the user is constrained to the 3 values). I decided to validate the data by handling the typing discrepancy between Taskwarrior's due property and the way we've been handling it.

In the attempt to handle the discrepancy, you'll see that a `QDateEdit` object replaced the previous textbox. The default value is always set to the day after the current day, and clicking the arrow opens a pop-out calendar that can be used to quickly set the due date. The due parameter is serialized in the api's add and update functions as text for use in other places in the API that require that information. 

An unintended side effect of this PR is that the due date is partially visible on the task table interface when the due date is edited. I believe that the entire date will be visible if that column is made wider.