### PR TITLE
Feature no priority

### DIFF
--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -48,6 +48,7 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.due_date = QtWidgets.QDateEdit()
         self.due_date.setDateTime(self.due_date.dateTime().currentDateTime())
 
+        self.priorities.addItem("None")
         self.priorities.addItem("H")
         self.priorities.addItem("M")
         self.priorities.addItem("L")
@@ -81,14 +82,21 @@ class AddTaskDialog(QtWidgets.QDialog):
 
     def add_task(self) -> Optional[TaskDetails]:
         if self.exec():
-            if self.is_recurring:
-                return AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(), 
-                                             self.project.text(), self.recurrence.currentText(), self.due_date.dateTime().toPython())
-            else:
-                return AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(), 
-                                             self.project.text(), None, None)
+            if not self.is_recurring:  # If the task is not recurring
+                self.recurrence = None  # Set the recurrence to None
+                self.due_date = None  # Set the due date to None
+            else:  # If the task is recurring
+                self.recurrence = self.recurrence.currentText()  # Set the recurrence to the current text of the recurrence field
+                self.due_date = self.due_date.dateTime().toPython()  # Set the due date to the due date field
+
+            if self.priorities.currentText() == "None":  # If the priority is None
+                self.priorities.clear()  # Clear the priority field
+
+
+            return AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(),
+                                             self.project.text(), self.recurrence, self.due_date)  # Return the task details
         else:
             return None
-    
+        #
     def open_recurrence(self) -> None:
         self.is_recurring = self.recurring_box.isChecked()

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -107,7 +107,7 @@ class XPConfigDialog(QDialog):
                 return json.load(file)
         except (FileNotFoundError, json.JSONDecodeError):
             # return some arbitrary default config if the file doesn't exist
-            return {"priorities": {'H': 10, 'M': 5, 'L': 1}, "tags": {}, "projects": {}}
+            return {"priorities": {'H': 10, 'M': 5, 'L': 1, None: 0.5}, "tags": {}, "projects": {}}
 
 
     def save_config(self):

--- a/components/GUI/task_champion_gui.py
+++ b/components/GUI/task_champion_gui.py
@@ -17,6 +17,16 @@
 
 from PySide6 import QtWidgets
 from components.GUI.task_champion_widget import TaskChampionWidget
+from PySide6.QtCore import qInstallMessageHandler, Qt
+
+
+def handler(msg_type, context, msg):
+    """Suppresses QSS style sheet warnings (which are not errors)."""
+    if "Could not parse" in msg:  # If the message contains "Could not parse"
+        pass  # Do nothing.
+
+qInstallMessageHandler(handler)  # Install the message handler.
+
 
 class TaskChampionGUI:
     """The main application class for Task Champion."""  

--- a/components/GUI/xp_controller_widget.py
+++ b/components/GUI/xp_controller_widget.py
@@ -55,7 +55,7 @@ class XpControllerWidget(QtWidgets.QWidget):
         int
             The computed completion value after applying all relevant multipliers.
         """
-        completion_value : int = XpControllerWidget.PRIORITY_MULT_MAP[priority]  # Get the base completion value
+        completion_value = XpControllerWidget.PRIORITY_MULT_MAP.get(priority, 0.5)  # Get the completion value. If the priority is not in the priority multiplier map, set the multiplier to 0.5
 
         if projects is not None:
             for project in projects:  # For each project

--- a/utils/task.py
+++ b/utils/task.py
@@ -60,7 +60,11 @@ class Task(task.Task):
         return self['parent']  # Return the parent field.
 
     def get_priority(self) -> priority_t:
-        return cast(priority_t, str(self['priority']))  # Return the priority field.
+        try:  # Try to return the priority field.
+            return cast(priority_t, str(self['priority']))  # Return the priority field.
+        except KeyError:  # If the priority field does not exist
+            return None  # Return None
+        # return cast(priority_t, str(self['priority']))  # Return the priority field.
     
     def set_priority(self, priority : str) -> None:
         self.set("priority", priority)  # Set the priority field to the given priority.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3d526a5e-5158-46c6-b580-2701c14b61a4)

- The app no longer crashes when importing priority-less tasks.
- `Add Task` allows and defaults to no-priority.
- Suppressed style sheet parsing warnings which did not affect functionality.