### PR TITLE
Refactor xp config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# TaskChampion Specific
+config/
+logs/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -30,9 +30,9 @@ class XPConfigDialog(QDialog):
     PRIORITY_T = ["H", "M", "L"]
     xp_values_updated = Signal(dict) # Signal to indicate that the XP values have been updated
 
-    def __init__(self, config_file="components/config/user_defined_xp.json"):
+    def __init__(self, config_file="config/user_defined_xp.json"):
         super().__init__()
-        os.makedirs('components/config/', exist_ok=True)
+        os.makedirs('config/', exist_ok=True)
         self.setWindowTitle("Edit XP Configuration")
         self.config_file = config_file
         self.config: dict[str, Any] = self.load_config()
@@ -117,17 +117,17 @@ class XPConfigDialog(QDialog):
         projects = {}
         for row in range(self.priority_table.rowCount()):
             priority = self.priority_table.item(row, 0).text()
-            xp = int(self.priority_table.item(row, 1).text())
+            xp = float(self.priority_table.item(row, 1).text())
             priorities[priority] = xp
 
         for row in range(self.tag_table.rowCount()):
             tag = self.tag_table.item(row, 0).text()
-            xp = int(self.tag_table.item(row, 1).text())
+            xp = float(self.tag_table.item(row, 1).text())
             tags[tag] = xp
 
         for row in range(self.project_table.rowCount()):
             project = self.project_table.item(row, 0).text()
-            xp = int(self.project_table.item(row, 1).text())
+            xp = float(self.project_table.item(row, 1).text())
             projects[project] = xp
             
         self.config['priorities'] = priorities # Update the priorities
@@ -138,7 +138,7 @@ class XPConfigDialog(QDialog):
         self.xp_values_updated.emit(self.config)
 
         with open(self.config_file, 'w') as file:
-            json.dump(self.config, file)
+            json.dump(self.config, file, indent=2)
 
         QMessageBox.information(self, "Success", "Configuration saved!", QMessageBox.StandardButtons.Ok)
 

--- a/components/Dialogs/define_xp_dialog.py
+++ b/components/Dialogs/define_xp_dialog.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import QDialog, QVBoxLayout, QTableWidget, QPushButton, Q
     QMessageBox, QComboBox
 from PySide6.QtCore import Signal
 from typing import Any
+from utils.config_loader import load_config, save_config
 import os
 
 class XPConfigDialog(QDialog):
@@ -35,7 +36,7 @@ class XPConfigDialog(QDialog):
         os.makedirs('config/', exist_ok=True)
         self.setWindowTitle("Edit XP Configuration")
         self.config_file = config_file
-        self.config: dict[str, Any] = self.load_config()
+        self.config: dict[str, Any] = load_config(self.config_file)
 
         # Layout
         layout = QVBoxLayout(self)
@@ -89,27 +90,6 @@ class XPConfigDialog(QDialog):
         save_button.clicked.connect(self.save_config)
         layout.addWidget(save_button)
 
-    def load_config(self):
-        """
-        Loads configuration data from a file into a dictionary attribute.
-
-        This method reads a JSON formatted configuration file specified by the
-        `config_file` attribute and populates the `config` attribute with the
-        parsed content.
-
-        Raises:
-            FileNotFoundError: If the configuration file does not exist.
-            json.JSONDecodeError: If the configuration file's contents are not
-                valid JSON.
-        """
-        try:
-            with open(self.config_file, 'r') as file:
-                return json.load(file)
-        except (FileNotFoundError, json.JSONDecodeError):
-            # return some arbitrary default config if the file doesn't exist
-            return {"priorities": {'H': 10, 'M': 5, 'L': 1, None: 0.5}, "tags": {}, "projects": {}}
-
-
     def save_config(self):
         # Save table data back to the config file
         priorities = {}
@@ -137,8 +117,7 @@ class XPConfigDialog(QDialog):
         # Tell XpControllerWidget to update stuff.
         self.xp_values_updated.emit(self.config)
 
-        with open(self.config_file, 'w') as file:
-            json.dump(self.config, file, indent=2)
+        save_config(self.config, self.config_file)
 
         QMessageBox.information(self, "Success", "Configuration saved!", QMessageBox.StandardButtons.Ok)
 

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -1,0 +1,25 @@
+import json
+
+def load_config(config_file):
+    """
+    Loads configuration data from a file into a dictionary attribute.
+
+    This method reads a JSON formatted configuration file specified by the
+    `config_file` attribute and populates the `config` attribute with the
+    parsed content.
+
+    Raises:
+        FileNotFoundError: If the configuration file does not exist.
+        json.JSONDecodeError: If the configuration file's contents are not
+            valid JSON.
+    """
+    try:
+        with open(config_file, 'r') as file:
+            return json.load(file)
+    except (FileNotFoundError, json.JSONDecodeError):
+        # return some arbitrary default config if the file doesn't exist
+        return {"priorities": {'H': 10, 'M': 5, 'L': 1, None: 0.5}, "tags": {}, "projects": {}}
+
+def save_config(config, config_file):
+    with open(config_file, 'w') as file:
+        json.dump(config, file, indent=2)


### PR DESCRIPTION
Move save/load functionality to a separate file.
Move config folder out of components.
Make JSON pretty print with indents.
Allow values to be floats.