### PR TITLE
Refactor moving deletion

### DIFF
--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -93,9 +93,12 @@ class AddTaskDialog(QtWidgets.QDialog):
                 self.priorities.clear()  # Clear the priority field
 
 
-            return AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(),
+            task_details = AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(),
                                              self.project.text(), self.recurrence, self.due_date)  # Return the task details
+            self.description.clear() # Clear the description field so the text doesn't repopulate on the next task creation
+            return task_details
         else:
+            self.description.clear() # Clear the description field so the text doesn't repopulate on the next task creation
             return None
         #
     def open_recurrence(self) -> None:

--- a/components/Dialogs/edit_task_dialog.py
+++ b/components/Dialogs/edit_task_dialog.py
@@ -18,10 +18,10 @@
 from PySide6 import QtWidgets
 
 class EditTaskDialog(QtWidgets.QDialog):
-    def __init__(self, deletion_function, description="", due="", priority=""):
+    def __init__(self, delete_task, description="", due="", priority=""):
         super().__init__()
         self.form = QtWidgets.QFormLayout()
-        self.deletion_function = deletion_function
+        self.deletion_function = delete_task
 
         self.description_text = QtWidgets.QLineEdit(description) # set the description text to the description of the task
 
@@ -50,8 +50,7 @@ class EditTaskDialog(QtWidgets.QDialog):
                                       | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
         self.delete_button = QtWidgets.QPushButton("Delete Task")
-        self.delete_button.clicked.connect(self.confirm_deletion)
-
+        self.delete_button.clicked.connect(self.delete)
 
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(self.form)
@@ -88,16 +87,13 @@ class EditTaskDialog(QtWidgets.QDialog):
             return ""
         return self.priority_text.currentText()
 
-    def delete_task(self):
-        self.deletion_function()
-        self.accept()
-
-    def confirm_deletion(self):
+    def delete(self):
         response = QtWidgets.QMessageBox.question(self, "Delete Task", "Are you sure you want to delete this task?",
                                                   QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
 
         if response == QtWidgets.QMessageBox.StandardButton.Yes: # If the user clicks Yes, the task will be deleted.
-            self.delete_task()
+            self.deletion_function()
+            self.accept()
 
         else: # If the user doesn't want to delete the task, then the dialog will close.
             return

--- a/components/Dialogs/edit_task_dialog.py
+++ b/components/Dialogs/edit_task_dialog.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 3/7/2025
+ *  Last Modified: 3/14/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -18,9 +18,10 @@
 from PySide6 import QtWidgets
 
 class EditTaskDialog(QtWidgets.QDialog):
-    def __init__(self, description="", due="", priority=""):
+    def __init__(self, deletion_function, description="", due="", priority=""):
         super().__init__()
         self.form = QtWidgets.QFormLayout()
+        self.deletion_function = deletion_function
 
         self.description_text = QtWidgets.QLineEdit(description) # set the description text to the description of the task
 
@@ -48,9 +49,14 @@ class EditTaskDialog(QtWidgets.QDialog):
         button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
                                       | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
+        self.delete_button = QtWidgets.QPushButton("Delete Task")
+        self.delete_button.clicked.connect(self.confirm_deletion)
+
+
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(self.form)
         layout.addWidget(button_box)
+        layout.addWidget(self.delete_button)
 
         self.setLayout(layout)
 
@@ -81,4 +87,17 @@ class EditTaskDialog(QtWidgets.QDialog):
         if self.priority_text.currentText() == "None":
             return ""
         return self.priority_text.currentText()
-        # return self.priority_text.currentText()
+
+    def delete_task(self):
+        self.deletion_function()
+        self.accept()
+
+    def confirm_deletion(self):
+        response = QtWidgets.QMessageBox.question(self, "Delete Task", "Are you sure you want to delete this task?",
+                                                  QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+
+        if response == QtWidgets.QMessageBox.StandardButton.Yes: # If the user clicks Yes, the task will be deleted.
+            self.delete_task()
+
+        else: # If the user doesn't want to delete the task, then the dialog will close.
+            return

--- a/components/GUI/tablecell.py
+++ b/components/GUI/tablecell.py
@@ -4,9 +4,9 @@
  *  Inputs: None
  *  Outputs: None
  *  Additional code sources: None
- *  Developers: Ethan Berkley
+ *  Developers: Ethan Berkley, Mo Morgan
  *  Date: 2/15/2025
- *  Last Modified: 2/23/2025
+ *  Last Modified: 3/14/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -43,9 +43,15 @@ class TableCell(QtWidgets.QLabel):
         self.my_layout.addWidget(self.get_sub_widget())  # Add the sub widget to the layout.
 
     def update_task(self):
+        """
+        Updates the task and its active state.
+
+        This method retrieves a task using the get_task method and updates the active state based
+        on whether the task exists.
+
+        Args: None
+        """
         self.task = self.get_task()  # Get the task from the get task method.
         self.active = self.task is not None  # Set the active variable to True if the task is not None.
 
         self.setProperty('row-active', str(self.active))  # Set the row active property of the cell.
-
-        

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -119,7 +119,7 @@ class TaskRow:
             return  # Return.
 
         edit_task_dialog = EditTaskDialog(
-            deletion_function=self.delete_task,
+            delete_task=self.delete_task,
             description=str(self.task.get("description") or ""),
             due=str(self.task.get("due") or ""),
             priority=str(self.task.get("priority") or ""))  # Create an instance of the EditTaskDialog class.
@@ -143,7 +143,6 @@ class TaskRow:
 
         # Get the current row index
         row_idx = grid.indexOf(self.check)  # Get the index of the checkbox.
-
 
         # Loop through the widgets in the row and remove them
         for widget in [self.check] + self.cols + [self.edit_button]:

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -62,7 +62,6 @@ class TaskRow:
         self.cols = [Textbox(row_num, self.get_task, attr) for attr in COLS]  # Create a list of textboxes.
 
         self.edit_button = ButtonBox(row_num, self.get_task, "edit", self.edit_task)  # Create an edit button.
-        self.delete_button = ButtonBox(row_num, self.get_task, "delete", self.delete_task)  # Create a delete button.
 
         # Initial fetch of function calls
         if self.task is not None:
@@ -96,13 +95,21 @@ class TaskRow:
         grid.addWidget(self.edit_button, row_num, len(self.cols) + 1)  # Add the edit button
 
     def update_task(self):
+        """
+        Updates the task elements and associated components within the application.
+        This method retrieves the task at the specified index, updates associated
+        checkbox, column elements, edit and delete buttons, and binds external
+        functions if the task is valid.
+
+        Returns:
+            None
+        """
         self.task = api.task_at(self.idx)  # Get the task at the index.
 
         self.check.update_task()  # Update the checkbox.
         for i in range(len(self.cols)):  # Loop through the columns.
             self.cols[i].update_task()  # Update the column.
         self.edit_button.update_task()  # Update the edit button.
-        self.delete_button.update_task()  # Update the delete button.
 
         if self.task is not None:  # If the task is not None.
             self._bind_xp_fns(self.fetch_xp_brs(self.task))  # Bind the xp functions.

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 3/10/2025
+ *  Last Modified: 3/14/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -105,9 +105,11 @@ class TaskRow:
         if not self.task:  # If the task is None.
             return  # Return.
 
-        edit_task_dialog = EditTaskDialog(str(self.task.get("description") or ""),
-            str(self.task.get("due") or ""),
-            str(self.task.get("priority") or ""))  # Create an instance of the EditTaskDialog class.
+        edit_task_dialog = EditTaskDialog(
+            deletion_function=self.delete_task,
+            description=str(self.task.get("description") or ""),
+            due=str(self.task.get("due") or ""),
+            priority=str(self.task.get("priority") or ""))  # Create an instance of the EditTaskDialog class.
 
         if edit_task_dialog.exec():  # If the dialog is executed.
             self.task.set("description", edit_task_dialog.description or None)  # Set the description of the task.

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -9,10 +9,10 @@
  *  Last Modified: 3/14/2025
  *  Preconditions: None
  *  Postconditions: None
- *  Error/Exception conditions: None
+ *  Error/Exception conditions: If attempting to add a task after another task has been deleted
  *  Side effects: None
  *  Invariants: None
- *  Known Faults: None encountered
+ *  Known Faults: RuntimeError: Internal C++ object (Checkbox) already deleted.
 """
 
 from PySide6 import QtWidgets
@@ -133,6 +133,10 @@ class TaskRow:
         grid = self.check.parentWidget().layout()  # Get the layout of the parent widget.
         if not grid:  # If the grid is None.
             return  # Return.
+
+        # Get the current row index
+        row_idx = grid.indexOf(self.check)  # Get the index of the checkbox.
+
 
         # Loop through the widgets in the row and remove them
         for widget in [self.check] + self.cols + [self.edit_button]:

--- a/components/GUI/task_row.py
+++ b/components/GUI/task_row.py
@@ -86,12 +86,9 @@ class TaskRow:
 
         # Set fixed sizes for buttons
         self.edit_button.setFixedWidth(60)  # Set the fixed width of the edit button.
-        self.delete_button.setFixedWidth(65)  # Set the fixed width of the delete button.
         self.edit_button.setFixedHeight(column_height)  # Set the fixed height of the edit button.
-        self.delete_button.setFixedHeight(column_height)  # Set the fixed height of the delete button.
 
         grid.addWidget(self.edit_button, row_num, len(self.cols) + 1)  # Add the edit button
-        grid.addWidget(self.delete_button, row_num, len(self.cols) + 2)  # Add the delete button
 
     def update_task(self):
         self.task = api.task_at(self.idx)  # Get the task at the index.
@@ -100,7 +97,6 @@ class TaskRow:
         for i in range(len(self.cols)):  # Loop through the columns.
             self.cols[i].update_task()  # Update the column.
         self.edit_button.update_task()  # Update the edit button.
-        self.delete_button.update_task()  # Update the delete button.
 
         if self.task is not None:  # If the task is not None.
             self._bind_xp_fns(self.fetch_xp_brs(self.task))  # Bind the xp functions.
@@ -131,7 +127,7 @@ class TaskRow:
             return  # Return.
 
         # Loop through the widgets in the row and remove them
-        for widget in [self.check] + self.cols + [self.edit_button, self.delete_button]:
+        for widget in [self.check] + self.cols + [self.edit_button]:
             grid.removeWidget(widget)  # Remove the widget from the grid.
             widget.deleteLater()  # Delete the widget.
         # add an empty row to the grid to maintain the same number of rows
@@ -144,7 +140,7 @@ class TaskRow:
             return  # Return.
 
         # Loop through the widgets in the row and remove them
-        for widget in [self.check] + self.cols + [self.edit_button, self.delete_button]:  # Loop through the widgets.
+        for widget in [self.check] + self.cols + [self.edit_button]:  # Loop through the widgets.
             grid.removeWidget(widget)  # Remove the widget from the grid.
             widget.deleteLater()  # Delete the widget.
         # add an empty row to the grid to maintain the same number of rows


### PR DESCRIPTION
This closes #40.

The delete button has been moved from the main task interface...
![image](https://github.com/user-attachments/assets/a2b4fc2d-7392-49ae-8054-c34d50ae0709)

...to the edit dialog.
![image](https://github.com/user-attachments/assets/ef9da8a2-c5ba-4d05-bba0-3ca3d7cde3d4)

In the edit dialog, the button has been renamed from "delete" to "Delete Task" to avoid any ambiguity as to what is deleted upon the button press. The delete button is located below the standard buttons instead of being inline with them to minimize accidentally pressing the delete button. A further countermeasure is the inclusion of a confirmation window when the delete button is pressed.

![image](https://github.com/user-attachments/assets/52bd556b-7461-4cf2-8d0a-2a3a41f8195b)

When No is clicked, the confirmation window closes and the edit dialog remains open. When Yes is clicked, both the confirmation window and edit dialog are closed and the task is deleted.

The prologue comments have been updated with a known fault that I encountered in this PR...

![image](https://github.com/user-attachments/assets/ac0a6946-0e28-4a1e-bfb2-02220750a793)

The delete function refactor is still live and assigned to @richardmoser, so I didn't implement a solution for the fault.

Another place of future work would be a UI fix for the extra space left after getting rid of the extra space between the edit button column of task rows and the vertical scrolling bar shown here:

![image](https://github.com/user-attachments/assets/54b4dd63-9e4f-4ea8-b2f1-3652009e18b7)

I attempted several changes to fix this including: deleting 'delete' from COLUMN_WIDTHS, deleting 'delete' from COLUMN_STRETCH, decrementing COL_STRETCH by 1. This is a good future issue to refactor.
