### PR TITLE
Add Tag Selection

### DIFF
--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -6,7 +6,7 @@
  *  Additional code sources: None
  *  Developers: Ethan Berkley, Jacob Wilkus, Mo Morgan, Richard Moser, Derek Norton
  *  Date: 2/15/2025
- *  Last Modified: 2/28/2025
+ *  Last Modified: 3/16/2025
  *  Preconditions: None
  *  Postconditions: None
  *  Error/Exception conditions: None
@@ -15,12 +15,12 @@
  *  Known Faults: None encountered
 """
 
-from PySide6 import QtWidgets
+from PySide6 import QtWidgets, QtCore, QtGui
 from typing import Optional
 
 class AddTaskDialog(QtWidgets.QDialog):
     class TaskDetails:
-        def __init__(self, description : str, tag : str, priority : str, project : str, recurrence : Optional[str], due : Optional[object]):
+        def __init__(self, description: str, tag: str, priority: str, project: str, recurrence: Optional[str], due: Optional[object]):
             self.description = description
             self.tag = tag
             self.priority = priority
@@ -29,48 +29,37 @@ class AddTaskDialog(QtWidgets.QDialog):
             self.due = due
 
     def __init__(self):
-
         super().__init__()
 
         self.form = QtWidgets.QFormLayout()
 
         self.description = QtWidgets.QLineEdit()
         self.tag = QtWidgets.QLineEdit()
-        self.priorities = QtWidgets.QComboBox()
+        self.priority = QtWidgets.QComboBox()
         self.project = QtWidgets.QLineEdit()
         self.recurring_box = QtWidgets.QCheckBox()
 
         self.is_recurring = False
-
         self.recurring_box.stateChanged.connect(self.open_recurrence)
 
         self.recurrence = QtWidgets.QComboBox()
         self.due_date = QtWidgets.QDateEdit()
         self.due_date.setDateTime(self.due_date.dateTime().currentDateTime())
 
-        self.priorities.addItem("None")
-        self.priorities.addItem("H")
-        self.priorities.addItem("M")
-        self.priorities.addItem("L")
-
-        self.recurrence.addItem("daily")
-        self.recurrence.addItem("weekly")
-        self.recurrence.addItem("monthly")
-        self.recurrence.addItem("yearly")
+        self.priority.addItems(["None", "H", "M", "L"])
+        self.recurrence.addItems(["daily", "weekly", "monthly", "yearly"])
 
         self.buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
-                                      | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+                                                  | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
         self.form.addRow("Description*", self.description)
-        self.form.addRow("Tag", self.tag)
-        self.form.addRow("Priority", self.priorities)
+        self.form.addRow("Priority", self.priority)
         self.form.addRow("Project", self.project)
         self.form.addRow("Is Recurring?", self.recurring_box)
         self.form.addRow("Recurrence", self.recurrence)
         self.form.addRow("Due Date", self.due_date)
 
-        self.layout : QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
-
+        self.layout: QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
         self.layout.addLayout(self.form)
         self.layout.addWidget(self.buttons)
 
@@ -79,6 +68,72 @@ class AddTaskDialog(QtWidgets.QDialog):
 
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
+
+        # Store previously used tags
+        self.tag_history = []
+        self.tags_list = []
+
+        # Create "Add Tag" button
+        self.add_tag_button = QtWidgets.QPushButton("Add Tag")
+        self.add_tag_button.clicked.connect(self.add_tag_to_list)
+
+        # Create a layout to hold the tag input field and button side by side
+        self.tag_layout = QtWidgets.QHBoxLayout()
+        self.tag_layout.addWidget(self.tag)
+        self.tag_layout.addWidget(self.add_tag_button)
+
+        # Add this new layout to the form
+        self.form.addRow("Tag", self.tag_layout)
+
+        # Create a layout to hold the added tag "bubbles"
+        self.tag_bubble_widget = QtWidgets.QWidget()
+        self.tag_bubble_layout = QtWidgets.QHBoxLayout(self.tag_bubble_widget)
+        self.tag_bubble_layout.setContentsMargins(0, 0, 0, 0)
+        self.tag_bubble_layout.setSpacing(5)  # Space between tags
+        self.form.addRow(self.tag_bubble_widget)
+
+        self.tag.mousePressEvent = self.show_tag_menu # Connect tag input field to show menu on focus
+
+    def show_tag_menu(self, event):
+        menu = QtWidgets.QMenu(self)
+
+        for tag in self.tag_history: # Add tag actions from the history
+            action = menu.addAction(tag)
+            action.triggered.connect(lambda checked, t=tag: self.tag.setText(t))
+
+        menu.setFixedWidth(self.tag.width()) # Set menu width equal to tag input field width
+
+        menu.exec(self.tag.mapToGlobal(self.tag.rect().bottomLeft()))  # Show menu below the input field
+
+    def add_tag_to_list(self):
+        tag_text = self.tag.text().strip()
+        if tag_text == '': #if button is pressed while empty skips adding
+            return
+        if tag_text and tag_text not in self.tag_history: 
+            self.tag_history.append(tag_text)  # Add the tag to history
+
+        if tag_text not in self.tags_list: #if tag is already added dont add the new tag
+            self.tags_list.append(tag_text) #add the new tag name to the list of tags present
+            tag_button = QtWidgets.QPushButton(tag_text)
+            tag_button.setStyleSheet("""  
+                QPushButton {
+                    background-color: white;
+                    border: 2px solid #ccc;
+                    border-radius: 12px;
+                    padding: 5px 10px;
+                    margin: 5px;
+                }
+                QPushButton:hover {
+                    background-color: #f0f0f0;
+                }
+            """) # Create a button for the tag, styled like a bubble
+
+            tag_button.clicked.connect(lambda: self.remove_tag(tag_button)) # remove tag when clicked
+
+            tag_button.setFixedSize(tag_button.sizeHint())  # Ensure the size is adjusted properly
+            self.tag_bubble_layout.addWidget(tag_button)  # Add the tag button to the layout
+
+        self.tag.clear()  # Clear the input field after adding the tag
 
     def add_task(self) -> Optional[TaskDetails]:
         if self.exec():
@@ -89,14 +144,37 @@ class AddTaskDialog(QtWidgets.QDialog):
                 self.recurrence = self.recurrence.currentText()  # Set the recurrence to the current text of the recurrence field
                 self.due_date = self.due_date.dateTime().toPython()  # Set the due date to the due date field
 
-            if self.priorities.currentText() == "None":  # If the priority is None
-                self.priorities.clear()  # Clear the priority field
+            if self.priority.currentText() == "None":  # If the priority is None
+                self.priority.clear()  # Clear the priority field
 
 
-            return AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(),
-                                             self.project.text(), self.recurrence, self.due_date)  # Return the task details
-        else:
-            return None
-        #
+            task_details = AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priority.currentText(),
+                                                     self.project.text(), self.recurrence, self.due_date) # create a variable for the task details
+
+            # Reset the input fields after adding the task
+            self.tag.clear()
+            self.tags_list.clear()
+            self.description.clear()
+            self.project.clear()
+            self.priority.setCurrentIndex(0)
+            self.remove_all_tags()
+
+            return task_details # Return the task details
+        return None
+
+    def remove_tag(self, tag_button):
+        """Remove a tag from the UI only."""
+        self.tags_list.remove(tag_button.text()) #remove the tag from the tags list
+        self.tag_bubble_layout.removeWidget(tag_button)  # Remove from layout
+        tag_button.deleteLater()  # Delete the widget
+
+    def remove_all_tags(self):
+        for i in reversed(range(self.tag_bubble_layout.count())): #iterates through the tags to remove all tag bubbles
+            widget = self.tag_bubble_layout.itemAt(i).widget()
+            if widget:
+                self.tag_bubble_layout.removeWidget(widget) #removes widget
+                widget.deleteLater()  # Remove the widget and free memory
+
+
     def open_recurrence(self) -> None:
         self.is_recurring = self.recurring_box.isChecked()

--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -36,7 +36,7 @@ class AddTaskDialog(QtWidgets.QDialog):
 
         self.description = QtWidgets.QLineEdit()
         self.tag = QtWidgets.QLineEdit()
-        self.priority = QtWidgets.QComboBox()
+        self.priorities = QtWidgets.QComboBox()
         self.projects = QtWidgets.QComboBox()
         self.new_project = QtWidgets.QLineEdit()
         self.recurring_box = QtWidgets.QCheckBox()
@@ -49,14 +49,14 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.due_date = QtWidgets.QDateEdit()
         self.due_date.setDateTime(self.due_date.dateTime().currentDateTime())
 
-        self.priority.addItems(["None", "H", "M", "L"])
+        self.priorities.addItems(["None", "H", "M", "L"])
         self.recurrence.addItems(["daily", "weekly", "monthly", "yearly"])
 
         self.buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
                                       | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
         self.form.addRow("Description*", self.description)
-        self.form.addRow("Priority", self.priority)
+        self.form.addRow("Priority", self.priorities)
         self.form.addRow("Project", self.projects)
         self.form.addRow("New Project", self.new_project)
         self.form.addRow("Is Recurring?", self.recurring_box)
@@ -159,15 +159,15 @@ class AddTaskDialog(QtWidgets.QDialog):
                 self.recurrence = self.recurrence.currentText()  # Set the recurrence to the current text of the recurrence field
                 self.due_date = self.due_date.dateTime().toPython()  # Set the due date to the due date field
 
-            if self.priority.currentText() == "None":  # If the priority is None
-                self.priority.clear()  # Clear the priority field
+            if self.priorities.currentText() == "None":  # If the priority is None
+                self.priorities.clear()  # Clear the priority field
 
             task_project = self.projects.currentText()
             if self.projects.currentText() == "New Project...":
                 task_project = self.new_project.text()
 
 
-            task_details = AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priority.currentText(),
+            task_details = AddTaskDialog.TaskDetails(self.description.text(), self.tag.text(), self.priorities.currentText(),
                                                      task_project, self.recurrence, self.due_date) # create a variable for the task details
 
             # Reset the input fields after adding the task
@@ -175,7 +175,7 @@ class AddTaskDialog(QtWidgets.QDialog):
             self.tags_list.clear()
             self.description.clear()
             self.projects.clear()
-            self.priority.setCurrentIndex(0)
+            self.priorities.setCurrentIndex(0)
             self.remove_all_tags()
 
             return task_details # Return the task details

--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 class AddTaskDialog(QtWidgets.QDialog):
     class TaskDetails:
-        def __init__(self, description: str, tag: str, priority: str, project: str, recurrence: Optional[str], due: Optional[object]):
+        def __init__(self, description : str, tag: str, priority : str, project : str, recurrence : Optional[str], due : Optional[object]):
             self.description = description
             self.tag = tag
             self.priority = priority
@@ -29,6 +29,7 @@ class AddTaskDialog(QtWidgets.QDialog):
             self.due = due
 
     def __init__(self):
+
         super().__init__()
 
         self.form = QtWidgets.QFormLayout()
@@ -40,6 +41,7 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.recurring_box = QtWidgets.QCheckBox()
 
         self.is_recurring = False
+
         self.recurring_box.stateChanged.connect(self.open_recurrence)
 
         self.recurrence = QtWidgets.QComboBox()
@@ -50,7 +52,7 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.recurrence.addItems(["daily", "weekly", "monthly", "yearly"])
 
         self.buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
-                                                  | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+                                        | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
         self.form.addRow("Description*", self.description)
         self.form.addRow("Priority", self.priority)
@@ -59,7 +61,7 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.form.addRow("Recurrence", self.recurrence)
         self.form.addRow("Due Date", self.due_date)
 
-        self.layout: QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
+        self.layout : QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
         self.layout.addLayout(self.form)
         self.layout.addWidget(self.buttons)
 

--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 class AddTaskDialog(QtWidgets.QDialog):
     class TaskDetails:
-        def __init__(self, description : str, tag: str, priority : str, project : str, recurrence : Optional[str], due : Optional[object]):
+        def __init__(self, description : str, tag : str, priority : str, project : str, recurrence : Optional[str], due : Optional[object]):
             self.description = description
             self.tag = tag
             self.priority = priority
@@ -52,7 +52,7 @@ class AddTaskDialog(QtWidgets.QDialog):
         self.recurrence.addItems(["daily", "weekly", "monthly", "yearly"])
 
         self.buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
-                                        | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+                                      | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
         self.form.addRow("Description*", self.description)
         self.form.addRow("Priority", self.priority)

--- a/components/Dialogs/add_task_dialog.py
+++ b/components/Dialogs/add_task_dialog.py
@@ -179,6 +179,8 @@ class AddTaskDialog(QtWidgets.QDialog):
             self.remove_all_tags()
 
             return task_details # Return the task details
+
+        self.description.clear() # Clear the description field so the text doesn't repopulate on the next task creation
         return None
 
     def remove_tag(self, tag_button):


### PR DESCRIPTION
**Resolves ticket #43**


3.5.2 In the add task dialog, allow for the user to select from previously defined tags
![2025-03-16 (1)](https://github.com/user-attachments/assets/a81085d9-2b73-4b04-a57d-1b64d7327af8)


3.5.4 In the add task dialog, allow for the user to select & deselect multiple tags.
![2025-03-16](https://github.com/user-attachments/assets/61f955ee-89f2-47b1-ad26-eb1da7887f3a)



**FUNCTIONS ADDED:**
_-show_tag_menu(self, event)_ will show a drop-down menu from the tag input field where a user can select from recently used tags to use in a new task
 
-_add_tag_to_list(self)_ when called will create a clickable bubble below the tag input field that shows what tags have been added to the list of tags for the new task. The function includes built in protections that prevent adding the same tag twice. Any tags added will be usable in the _show_tag_menu(self, event)_ function. 

![2025-03-16 (2)](https://github.com/user-attachments/assets/902f2456-b2b9-46d8-8249-09726161e47b)


-_remove_tag(self, tag_button)_ will remove a tag that has been clicked from the tag list

-_remove_all_tags(self)_ removes all tag bubbles. This is only used when the user closes the add task menu for clean-up purposes.

![2025-03-16 (3)](https://github.com/user-attachments/assets/781aa420-ad84-42f0-85bb-39f21f27c2f2)


**MISC CHANGES/FIXES**
-reset all input fields once the menu has been closed (code shown in image above)
-created button to add a new tag to the list of tags (shown in image #1 and image #2 above to the right of tag input field)
-created list variables to store recently used tags and tags currently added