### PR TITLE
fixed style errors

### DIFF
--- a/components/GUI/grid_widget.py
+++ b/components/GUI/grid_widget.py
@@ -95,14 +95,14 @@ class GridWidget(QtWidgets.QWidget):
         # QLabel is just simple text.
         self.grid.addWidget(QtWidgets.QLabel("Done?"), 0, 0)  # Add a label to the grid.
         self.grid.addWidget(QtWidgets.QLabel(""), 0, 10)  # Add a blank label cell to the grid
-        self.grid.addWidget(QtWidgets.QLabel(""), 0, 11)  # Add a blank label cell to the grid
-
+        self.grid.itemAtPosition(0, 0).widget().setObjectName("rowLabels")
         self.grid.itemAtPosition(0, 0).widget().setStyleSheet(get_style("rowLabels"))  # set the style for the "Done?" label
+        self.grid.itemAtPosition(0, 10).widget().setObjectName("rowLabels")
         self.grid.itemAtPosition(0, 10).widget().setStyleSheet(get_style("rowLabels"))  # set the style for the blank label cell
-        self.grid.itemAtPosition(0, 11).widget().setStyleSheet(get_style("rowLabels"))  # set the style for the blank label cell
 
         for i in range(len(COLS)):  # Loop through the columns.
             self.grid.addWidget(QtWidgets.QLabel(COLS[i]), 0, i+1)  # Add a label to the grid.
+            self.grid.itemAtPosition(0, i+1).widget().setObjectName("rowLabels")
             self.grid.itemAtPosition(0, i+1).widget().setStyleSheet(get_style("rowLabels"))  # Set the style of the label to be the row labels style.
             self.grid.itemAtPosition(0, i+1).widget().setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)  # Set the alignment of the label to be centered.
 

--- a/components/GUI/task_champion_widget.py
+++ b/components/GUI/task_champion_widget.py
@@ -55,15 +55,13 @@ class TaskChampionWidget(QtWidgets.QWidget):
 
         self.grids = [GridWidget(load_styles, self.xp_bars.get_relevant_xp_bars), GridWidget(load_styles, self.xp_bars.get_relevant_xp_bars)]  # Create a list of grid widgets.
         self.main_tab.addTab(self.grids[0].scroll_area, "Example Tab")  # Add the first grid widget to the tab widget.
-        # self.main_tab.addTab(self.grids[1].scroll_area, "Example Empty Tab")  # Add the second grid widget to the tab widget.
-        self.main_tab.setStyleSheet(get_style('example_tab'))  # Set the style of the tab widget.
+
+        # TODO: Add example_tab style...
+        # self.main_tab.setStyleSheet(get_style('example_tab'))  # Set the style of the tab widget.
 
         # Set grid widget to take up 75% of the app's width.
         self.main_layout.setStretch(0, 3)  # Set the stretch of the first grid widget to 3.
         self.main_layout.setStretch(1, 1)  # Set the stretch of the second grid widget to 1.
-
-        # TODO: reinstate this when we have a second tab
-        # self.main_tab.addTab(self.grids[1].scroll_area, "Example Empty Tab")  # Add the second grid widget to the tab widget.
 
         self.current_grid = 0  # Set the current grid to 0.
 

--- a/styles/extra_styles.py
+++ b/styles/extra_styles.py
@@ -35,7 +35,6 @@ def get_style(style_name):
     if start == -1:  # If the style name is not found.
         return None
     
-    start = style_string.find("{", start) +1  # Find the opening curly brace.
     end = style_string.find("}", start)  # Find the closing curly brace.
     # print(f"Found style {style_name} contents: {style_string[start:end]}")
     return style_string[start:end+1]  # Return the style contents

--- a/styles/style.qss
+++ b/styles/style.qss
@@ -42,7 +42,7 @@ XpBarChild::chunk {
     border-radius:2px;
 
     text-align: center;
-}
+} */
 
 
 /* Example color styling. */
@@ -146,12 +146,12 @@ EditTaskDialog {
 
 
 
-
-"Done?" {
+/* Not sure what this was for */
+/* "Done?" {
     background-color: black;
     color: yellow;
     border: 2px solid yellow;
-}
+} */
 
 /* ### additional styles ### */
 #rowLabels {


### PR DESCRIPTION
Fixed the stream of errors that happen when you start the application.
Most were because of the way `get_style` was coded, where it wouldn't include the object name in the string returned.
The ones that said 'could not parse application stylesheet.' were because there was a style rule named `"Done?"` or something like that. I just commented that one out.

Finally, there was a get_style call for "example_tab", which doesn't exist in the style sheet. I commented out that call, I think we should add something similar to the sheet at some point.