### PR TITLE
Create the functionality that creates 3 example modules

### DIFF
--- a/components/Dialogs/preset_modules_dialog.py
+++ b/components/Dialogs/preset_modules_dialog.py
@@ -1,0 +1,50 @@
+""" Prologue:
+ *  Module Name: preset_modules_dialog.py
+ *  Purpose: The dialog box for adding a preset module to TaskChampion.
+ *  Inputs: None
+ *  Outputs: None
+ *  Additional code sources: None
+ *  Developers: Mo Morgan
+ *  Date: 4/25/2025
+ *  Last Modified: 4/27/2025
+ *  Preconditions: None
+ *  Postconditions: None
+ *  Error/Exception conditions: None
+ *  Side effects: None
+ *  Invariants: None
+ *  Known Faults: None encountered
+"""
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QPushButton
+
+class PresetModulesDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Preset Modules")
+        self.layout = QVBoxLayout()
+
+        # Add "Workouts" button
+        self.workouts_button = QPushButton("Workouts")
+        self.workouts_button.clicked.connect(lambda: self.set_selected_module("Workouts"))  # Connect the button to the select_workouts method
+        self.layout.addWidget(self.workouts_button)
+
+        # Add "Personal Finance" button
+        self.personal_finance_button = QPushButton("Personal Finance")
+        self.personal_finance_button.clicked.connect(lambda: self.set_selected_module("Personal Finance"))
+        self.layout.addWidget(self.personal_finance_button)
+
+        # Add "Programming Project" button
+        self.programming_project_button = QPushButton("Programming Project")
+        self.programming_project_button.clicked.connect(lambda: self.set_selected_module("Programming Project"))
+        self.layout.addWidget(self.programming_project_button)
+
+        self.selected_module = None
+        self.setLayout(self.layout)
+
+    # setter for selected_module
+    def set_selected_module(self, module_name):
+        self.selected_module = module_name
+        self.accept()
+
+    def get_selected_module(self):
+
+        return self.selected_module


### PR DESCRIPTION
This closes #73, #74, and #76.

I added a `Preset Modules` button to the `AddModuleDialog` object. 

![image](https://github.com/user-attachments/assets/c4aa0acc-b483-4260-b019-01c076e4b5a3)


When clicked, it opens a small dialog box with 3 different preset example modules for the user to choose from. EDIT: This window was very small every time I've ever seen it except for right now. 

![image](https://github.com/user-attachments/assets/7adb7f2b-b038-4052-8005-fa590555384e)

When an option is selected, a pop-up tells the user that they must restart the app in order to see the newly created example module.

![image](https://github.com/user-attachments/assets/e724a049-d239-44ee-b835-3e11fde2dda5)
